### PR TITLE
[FEAT] 학부모 쪽지건의 화면

### DIFF
--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SendingViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SendingViewController.swift
@@ -8,31 +8,151 @@
 import UIKit
 
 class SendingViewController: BaseViewController {
-
-    private let textLabel: UILabel = {
+    
+    var typed: MessageType = .absence
+    var opacityInt: Float = 0.0
+    
+    //MARK: - Text Labels (Switch 구문 써서 더 줄일 수 있을지?)
+    private let textLabelPurpose: UILabel = {
         let label = UILabel()
-        label.text = "학부모님 쪽지건의 준비중입니다 😎"
-        label.font = UIFont.systemFont(ofSize: 20)
+        label.text = "용건을 알려주세요"
+        label.font = UIFont.systemFont(ofSize: 18, weight: .bold)
+        label.textColor = .black
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    private let textLabelDate: UILabel = {
+        let label = UILabel()
+        label.text = "일시"
+        label.font = UIFont.systemFont(ofSize: 18, weight: .bold)
+        label.textColor = .black
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    private let textLabelReason: UILabel = {
+        let label = UILabel()
+        label.text = "사유"
+        label.font = UIFont.systemFont(ofSize: 18, weight: .bold)
         label.textColor = .black
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
     
+    // MARK: - Properties & Func (Message Type 선택 후 Date picker 다르게 노출)
+    private let messageTypes: [UIAction] = [
+        //TODO: - Messasge Type의 Absence, EarlyLeave와 연결하여 후속 작업 필요. "용건 선택" -> 결석 or 조퇴로 텍스트 변환. Date Picker 띄우기, 사유 쓰기, 데이터를 String으로 보내기 -> Firebase
+        UIAction(title: "결석", handler: { _ in
+            print("결석 누름")
+            }),
+        UIAction(title: "조퇴", handler: { _ in
+            print("조퇴 누름")
+            })
+    ]
+
+    //TODO: - 메시지 버튼 내 text와 image 간격 조정, 사이 구분선 삽입
+    private lazy var messageTypeButton: UIButton = {
+        var button = UIButton()
+        button.setTitle("용건 선택", for: .normal)
+        button.setTitle("결석", for: .selected)
+        button.setTitleColor(UIColor.black, for: .normal)
+        button.backgroundColor = .secondarySystemFill
+        button.titleLabel?.font = UIFont.systemFont(ofSize: 17, weight: .medium)
+        button.setImage(UIImage(systemName: "chevron.down"), for: .normal)
+        button.semanticContentAttribute = .forceRightToLeft
+        button.layer.borderWidth = 0
+        button.layer.borderColor = UIColor.systemBlue.cgColor
+        button.layer.cornerRadius = 10
+        button.tintColor = .systemGray
+        button.addAction(UIAction(handler: { _ in
+            self.opacityInt = 1.0
+        }), for: .touchUpInside)
+        button.menu = UIMenu(options: UIMenu.Options.displayInline,
+                             children: messageTypes)
+        button.showsMenuAsPrimaryAction = true
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+    
+    //MARK: - Date Picker Propoerties
+    //TODO: - messagetype 에서 결석을 선택할 때와 조퇴를 선택할 때 pickermode 변경
+    lazy var datePicker: UIDatePicker = {
+        let picker = UIDatePicker()
+        picker.datePickerMode = .date
+        picker.preferredDatePickerStyle = .compact
+        picker.locale = Locale(identifier: "ko-KR")
+        picker.translatesAutoresizingMaskIntoConstraints = false
+        return picker
+    }()
+    
+    //MARK: - 사유 입력 Text Field Property
+    //TODO: - Text Field 내 여백 padding 값 조절, 글자수 제한, 박스 외부 클릭했을 때 커서와 키보드 사라지게 등등
+    let textFieldForReason: UITextField = {
+        let textF = UITextField()
+        textF.text = "기본텍스트입니다"
+        textF.textColor = .black
+        textF.font = .systemFont(ofSize: 17, weight: .medium)
+        textF.backgroundColor = .secondarySystemFill
+        textF.layer.cornerRadius = 10
+        textF.translatesAutoresizingMaskIntoConstraints = false
+        return textF
+    }()
+
+    //MARK: - View Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        textFieldForReason.delegate = self
 
     }
+    //MARK: - Funcs
     override func render() {
-        view.addSubview(textLabel)
-        textLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
-        textLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
+        //MARK: - 결석, 조퇴 선택
+        view.addSubview(textLabelPurpose)
+        textLabelPurpose.heightAnchor.constraint(equalToConstant: 40).isActive = true
+        textLabelPurpose.topAnchor.constraint(equalTo: view.topAnchor, constant: 100).isActive = true
+        textLabelPurpose.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20).isActive = true
+        
+        view.addSubview(messageTypeButton)
+        messageTypeButton.topAnchor.constraint(equalTo: textLabelPurpose.bottomAnchor).isActive = true
+        messageTypeButton.heightAnchor.constraint(equalToConstant: 40).isActive = true
+        messageTypeButton.widthAnchor.constraint(equalToConstant: 300).isActive = true
+        messageTypeButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20).isActive = true
+        
+        //MARK: - 날짜 (시간) 선택
+        
+        view.addSubview(textLabelDate)
+        textLabelDate.layer.opacity = 1.0 //opacityInt
+        textLabelDate.heightAnchor.constraint(equalToConstant: 40).isActive = true
+        textLabelDate.topAnchor.constraint(equalTo: messageTypeButton.bottomAnchor, constant: 20).isActive = true
+        textLabelDate.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20).isActive = true
+        
+        view.addSubview(datePicker)
+        datePicker.layer.opacity = 1.0 //opacityInt
+        datePicker.topAnchor.constraint(equalTo: textLabelDate.bottomAnchor).isActive = true
+        messageTypeButton.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+        datePicker.heightAnchor.constraint(equalToConstant: 40).isActive = true
+        datePicker.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20).isActive = true
+        
+        //MARK: - 사유 입력
+        view.addSubview(textLabelReason)
+        textLabelReason.heightAnchor.constraint(equalToConstant: 40).isActive = true
+        textLabelReason.topAnchor.constraint(equalTo: datePicker.bottomAnchor, constant: 20).isActive = true
+        textLabelReason.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20).isActive = true
+
+        view.addSubview(textFieldForReason)
+        textFieldForReason.topAnchor.constraint(equalTo: textLabelReason.bottomAnchor).isActive = true
+        textFieldForReason.heightAnchor.constraint(equalToConstant: 40).isActive = true
+        textFieldForReason.widthAnchor.constraint(equalToConstant: 350).isActive = true
+        textFieldForReason.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20).isActive = true
     }
 
     override func configUI() {
         view.backgroundColor = .primaryBackground
+
     }
-    
+}
 
-
-
+extension SendingViewController: UITextFieldDelegate {
+    func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
+        true
+    }
 }

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SendingViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SendingViewController.swift
@@ -9,10 +9,6 @@ import UIKit
 
 class SendingViewController: BaseViewController {
     
-    var typed: MessageType = .absence
-    var opacityInt: Float = 0.0
-    var button = UIButton()
-    
     //MARK: - Properties
     //Text Labels (Switch 구문 써서 더 줄일 수 있을지?)
     private let textLabelPurpose: UILabel = {
@@ -41,17 +37,12 @@ class SendingViewController: BaseViewController {
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
-    
-    // MARK: - Properties
-    // & Funcs (Message Type 선택 후 Date picker 다르게 노출)
-
 
     //TODO: -
     //메시지 버튼 내 text와 image 간격 조정, 사이 구분선 삽입
     private let messageTypeButton: UIButton = {
-        var button = UIButton()
+        let button = UIButton()
         button.setTitle("용건 선택", for: .normal)
-        button.setTitle("결석", for: .selected)
         button.setTitleColor(UIColor.black, for: .normal)
         button.backgroundColor = .secondarySystemFill
         button.titleLabel?.font = UIFont.systemFont(ofSize: 17, weight: .medium)

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SendingViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SendingViewController.swift
@@ -11,8 +11,10 @@ class SendingViewController: BaseViewController {
     
     var typed: MessageType = .absence
     var opacityInt: Float = 0.0
+    var button = UIButton()
     
-    //MARK: - Text Labels (Switch 구문 써서 더 줄일 수 있을지?)
+    //MARK: - Properties
+    //Text Labels (Switch 구문 써서 더 줄일 수 있을지?)
     private let textLabelPurpose: UILabel = {
         let label = UILabel()
         label.text = "용건을 알려주세요"
@@ -23,6 +25,7 @@ class SendingViewController: BaseViewController {
     }()
     private let textLabelDate: UILabel = {
         let label = UILabel()
+//        label.isHidden = true
         label.text = "일시"
         label.font = UIFont.systemFont(ofSize: 18, weight: .bold)
         label.textColor = .black
@@ -31,6 +34,7 @@ class SendingViewController: BaseViewController {
     }()
     private let textLabelReason: UILabel = {
         let label = UILabel()
+//        label.isHidden = true
         label.text = "사유"
         label.font = UIFont.systemFont(ofSize: 18, weight: .bold)
         label.textColor = .black
@@ -38,19 +42,13 @@ class SendingViewController: BaseViewController {
         return label
     }()
     
-    // MARK: - Properties & Func (Message Type 선택 후 Date picker 다르게 노출)
-    private let messageTypes: [UIAction] = [
-        //TODO: - Messasge Type의 Absence, EarlyLeave와 연결하여 후속 작업 필요. "용건 선택" -> 결석 or 조퇴로 텍스트 변환. Date Picker 띄우기, 사유 쓰기, 데이터를 String으로 보내기 -> Firebase
-        UIAction(title: "결석", handler: { _ in
-            print("결석 누름")
-            }),
-        UIAction(title: "조퇴", handler: { _ in
-            print("조퇴 누름")
-            })
-    ]
+    // MARK: - Properties
+    // & Funcs (Message Type 선택 후 Date picker 다르게 노출)
 
-    //TODO: - 메시지 버튼 내 text와 image 간격 조정, 사이 구분선 삽입
-    private lazy var messageTypeButton: UIButton = {
+
+    //TODO: -
+    //메시지 버튼 내 text와 image 간격 조정, 사이 구분선 삽입
+    private let messageTypeButton: UIButton = {
         var button = UIButton()
         button.setTitle("용건 선택", for: .normal)
         button.setTitle("결석", for: .selected)
@@ -63,31 +61,31 @@ class SendingViewController: BaseViewController {
         button.layer.borderColor = UIColor.systemBlue.cgColor
         button.layer.cornerRadius = 10
         button.tintColor = .systemGray
-        button.addAction(UIAction(handler: { _ in
-            self.opacityInt = 1.0
-        }), for: .touchUpInside)
-        button.menu = UIMenu(options: UIMenu.Options.displayInline,
-                             children: messageTypes)
         button.showsMenuAsPrimaryAction = true
         button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()
     
-    //MARK: - Date Picker Propoerties
-    //TODO: - messagetype 에서 결석을 선택할 때와 조퇴를 선택할 때 pickermode 변경
-    lazy var datePicker: UIDatePicker = {
+    //MARK: - Propoerties
+    //Date 입력 관련
+    //TODO: -
+    //messagetype 에서 결석을 선택할 때와 조퇴를 선택할 때 pickermode 변경
+    private let datePicker: UIDatePicker = {
         let picker = UIDatePicker()
-        picker.datePickerMode = .date
+//        picker.isHidden = true
         picker.preferredDatePickerStyle = .compact
         picker.locale = Locale(identifier: "ko-KR")
         picker.translatesAutoresizingMaskIntoConstraints = false
         return picker
     }()
     
-    //MARK: - 사유 입력 Text Field Property
-    //TODO: - Text Field 내 여백 padding 값 조절, 글자수 제한, 박스 외부 클릭했을 때 커서와 키보드 사라지게 등등
+    //MARK: - Properties
+    //사유 입력하는 Text Field View
+    //TODO: -
+    //Text Field 내 여백 padding 값 조절, 글자수 제한, 박스 외부 클릭했을 때 커서와 키보드 사라지게 등등
     let textFieldForReason: UITextField = {
         let textF = UITextField()
+//        textF.isHidden = true
         textF.text = "기본텍스트입니다"
         textF.textColor = .black
         textF.font = .systemFont(ofSize: 17, weight: .medium)
@@ -102,10 +100,11 @@ class SendingViewController: BaseViewController {
         super.viewDidLoad()
         textFieldForReason.delegate = self
 
+
     }
     //MARK: - Funcs
     override func render() {
-        //MARK: - 결석, 조퇴 선택
+
         view.addSubview(textLabelPurpose)
         textLabelPurpose.heightAnchor.constraint(equalToConstant: 40).isActive = true
         textLabelPurpose.topAnchor.constraint(equalTo: view.topAnchor, constant: 100).isActive = true
@@ -116,23 +115,18 @@ class SendingViewController: BaseViewController {
         messageTypeButton.heightAnchor.constraint(equalToConstant: 40).isActive = true
         messageTypeButton.widthAnchor.constraint(equalToConstant: 300).isActive = true
         messageTypeButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20).isActive = true
-        
-        //MARK: - 날짜 (시간) 선택
-        
+                
         view.addSubview(textLabelDate)
-        textLabelDate.layer.opacity = 1.0 //opacityInt
         textLabelDate.heightAnchor.constraint(equalToConstant: 40).isActive = true
         textLabelDate.topAnchor.constraint(equalTo: messageTypeButton.bottomAnchor, constant: 20).isActive = true
         textLabelDate.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20).isActive = true
         
         view.addSubview(datePicker)
-        datePicker.layer.opacity = 1.0 //opacityInt
         datePicker.topAnchor.constraint(equalTo: textLabelDate.bottomAnchor).isActive = true
         messageTypeButton.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
         datePicker.heightAnchor.constraint(equalToConstant: 40).isActive = true
         datePicker.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20).isActive = true
         
-        //MARK: - 사유 입력
         view.addSubview(textLabelReason)
         textLabelReason.heightAnchor.constraint(equalToConstant: 40).isActive = true
         textLabelReason.topAnchor.constraint(equalTo: datePicker.bottomAnchor, constant: 20).isActive = true
@@ -147,7 +141,25 @@ class SendingViewController: BaseViewController {
 
     override func configUI() {
         view.backgroundColor = .primaryBackground
-
+        
+        //Message Type 버튼과 선택에 따른 컴포넌트 노출 차이
+        messageTypeButton.menu = UIMenu(options: .displayInline, children: [
+            UIAction(title: "결석", handler: { _ in
+                self.messageTypeButton.setTitle("결석", for: .normal)
+//                self.textLabelDate.isHidden = false
+//                self.datePicker.isHidden = false
+                self.datePicker.datePickerMode = .date
+                print("결석 누름")
+            }),
+            UIAction(title: "조퇴", handler: { _ in
+                self.messageTypeButton.setTitle("조퇴", for: .normal)
+//                self.textLabelDate.isHidden = false
+//                self.datePicker.isHidden = false
+                self.datePicker.datePickerMode = .dateAndTime
+                print("조퇴 누름")
+            })
+        ])
+        
     }
 }
 

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SendingViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SendingViewController.swift
@@ -74,7 +74,7 @@ class SendingViewController: BaseViewController {
     //사유 입력하는 Text Field View
     //TODO: -
     //Text Field 내 여백 padding 값 조절, 글자수 제한, 박스 외부 클릭했을 때 커서와 키보드 사라지게 등등
-    let textFieldForReason: UITextField = {
+    private let textFieldForReason: UITextField = {
         let textF = UITextField()
 //        textF.isHidden = true
         textF.text = "기본텍스트입니다"


### PR DESCRIPTION
## 🍏 관련 이슈
#7 

## 🍏 작업내용

<img width="350" alt="image" src="https://user-images.githubusercontent.com/103012800/179928233-255c2859-c4dd-4d71-b2a3-a2a1b4a7a38b.png">
<img width="360" alt="image" src="https://user-images.githubusercontent.com/103012800/179928300-ed7b00b5-fc72-4a1b-b80f-987836679a40.png"> <img width="352" alt="image" src="https://user-images.githubusercontent.com/103012800/179928347-69f2ef95-ed96-44fd-a41a-599b6290d59e.png">


## 🍏 다음으로 진행될 작업
 - [ ] 용건입력 후 Date Picker, 그 후 사유가 순차적으로 뜨게 하기 (동적 화면)
 - [ ] Text Field 세부적이 세팅 Delegate 패턴 활용하여 조정
 - [ ] 문자 전송 내역 리스트 (학부모 입장)

## 🍏 주의사항
- **빈 폴더 있는지 확인하기!!**
- **파일,폴더 위치 및 이동 하지말기!!**
