### PR TITLE
[ADD] 교사 쪽지건의 탭 구현(Data Struct 구조 변경 및 MockData에 긴급메세지 추가)

### DIFF
--- a/Gajeongtongsin/Gajeongtongsin.xcodeproj/project.pbxproj
+++ b/Gajeongtongsin/Gajeongtongsin.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		359583A82882A6F7002B6873 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359583A72882A6F7002B6873 /* Constants.swift */; };
 		359583AA28840415002B6873 /* TestJ.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359583A928840415002B6873 /* TestJ.swift */; };
 		C04B547F2887C6250097EE88 /* MockData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04B547E2887C6250097EE88 /* MockData.swift */; };
+		C056F6AD288B0A770070EED5 /* MessageVIewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C056F6AC288B0A770070EED5 /* MessageVIewController.swift */; };
+		C056F6AF288B0A950070EED5 /* MessageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C056F6AE288B0A950070EED5 /* MessageTableViewCell.swift */; };
 		C0DFFBFD2885DC86009A1563 /* ParentUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DFFBFC2885DC86009A1563 /* ParentUser.swift */; };
 		C0DFFC032885DE32009A1563 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DFFC022885DE32009A1563 /* Message.swift */; };
 		C0DFFC052885DF05009A1563 /* Schedule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DFFC042885DF05009A1563 /* Schedule.swift */; };
@@ -85,6 +87,8 @@
 		359583A72882A6F7002B6873 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		359583A928840415002B6873 /* TestJ.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestJ.swift; sourceTree = "<group>"; };
 		C04B547E2887C6250097EE88 /* MockData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockData.swift; sourceTree = "<group>"; };
+		C056F6AC288B0A770070EED5 /* MessageVIewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageVIewController.swift; sourceTree = "<group>"; };
+		C056F6AE288B0A950070EED5 /* MessageTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageTableViewCell.swift; sourceTree = "<group>"; };
 		C0DFFBFC2885DC86009A1563 /* ParentUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentUser.swift; sourceTree = "<group>"; };
 		C0DFFC022885DE32009A1563 /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
 		C0DFFC042885DF05009A1563 /* Schedule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Schedule.swift; sourceTree = "<group>"; };
@@ -296,6 +300,7 @@
 				35958371288294F4002B6873 /* Component */,
 				35958370288294F0002B6873 /* Cell */,
 				3595837C288297E7002B6873 /* ReceivingViewController.swift */,
+				C056F6AC288B0A770070EED5 /* MessageVIewController.swift */,
 			);
 			path = Receiving;
 			sourceTree = "<group>";
@@ -352,6 +357,7 @@
 			isa = PBXGroup;
 			children = (
 				3595839A28829CA1002B6873 /* TestI.swift */,
+				C056F6AE288B0A950070EED5 /* MessageTableViewCell.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -486,6 +492,7 @@
 				C0DFFC072885DFEB009A1563 /* ScheduleInfo.swift in Sources */,
 				3595838928829C1D002B6873 /* Test.swift in Sources */,
 				3595839E28829D80002B6873 /* ProfileViewController.swift in Sources */,
+				C056F6AD288B0A770070EED5 /* MessageVIewController.swift in Sources */,
 				35171CFE28828C930059F297 /* AppDelegate.swift in Sources */,
 				359583A228829D93002B6873 /* TestK.swift in Sources */,
 				359583732882956C002B6873 /* BaseViewController.swift in Sources */,
@@ -495,6 +502,7 @@
 				3595837B288297D1002B6873 /* ReservationViewController.swift in Sources */,
 				3595839328829C82002B6873 /* TestD.swift in Sources */,
 				3558AB3928868D2800539C66 /* Notification.swift in Sources */,
+				C056F6AF288B0A950070EED5 /* MessageTableViewCell.swift in Sources */,
 				35958379288297B9002B6873 /* SendingViewController.swift in Sources */,
 				3595837F2882980C002B6873 /* StartViewController.swift in Sources */,
 				359583AA28840415002B6873 /* TestJ.swift in Sources */,

--- a/Gajeongtongsin/Gajeongtongsin/Global/Literal/MockData.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Global/Literal/MockData.swift
@@ -16,13 +16,16 @@ var parent3 = ParentUser(id: "3", sendingMessages: messageList3, childName: "최
 
 var messageList1 = [
     Message(type: .absence, sentDate: Date(), expectedDate: "7월21일", content: "김유쓰배아픔", isCompleted: false),
-    Message(type: .earlyLeave, sentDate: Date(), expectedDate: "7월22일", content: "김유쓰놀이공원", isCompleted: false)
+    Message(type: .earlyLeave, sentDate: Date(), expectedDate: "7월22일", content: "김유쓰놀이공원", isCompleted: false),
+    Message(type: .emergency, sentDate: Date(), expectedDate: "7월25일", content: "김유쓰실종", isCompleted: false)
 ]
 
 var messageList2 = [
     Message(type: .absence, sentDate: Date(), expectedDate: "7월23일", content: "부니카제주도", isCompleted: false),
-    Message(type: .earlyLeave, sentDate: Date(), expectedDate: "7월24일", content: "부니카서울", isCompleted: false)
-]
+    Message(type: .earlyLeave, sentDate: Date(), expectedDate: "7월24일", content: "부니카서울", isCompleted: false),
+    Message(type: .emergency, sentDate: Date(), expectedDate: "7월25일", content: "부니카1:10패싸움중(부니카가 1ㅋ)", isCompleted: false)
+    ]
+
 var messageList3 = [
     Message(type: .absence, sentDate: Date(), expectedDate: "7월25일", content: "최히로소개팅", isCompleted: false),
     Message(type: .earlyLeave, sentDate: Date(), expectedDate: "7월26일", content: "최히로레브랑데이트", isCompleted: false)

--- a/Gajeongtongsin/Gajeongtongsin/Models/Message.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Models/Message.swift
@@ -14,8 +14,8 @@ struct Message {
     let isCompleted: Bool      //task완료 여부(교사의 체크)
 }
 
-enum MessageType {
-    case absence
-    case earlyLeave
-    case emergency
+enum MessageType: String {
+    case absence = "결석"
+    case earlyLeave = "조퇴"
+    case emergency = "긴급"
 }

--- a/Gajeongtongsin/Gajeongtongsin/Models/Message.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Models/Message.swift
@@ -17,4 +17,5 @@ struct Message {
 enum MessageType {
     case absence
     case earlyLeave
+    case emergency
 }

--- a/Gajeongtongsin/Gajeongtongsin/Models/ParentUser.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Models/ParentUser.swift
@@ -12,4 +12,8 @@ struct ParentUser {
     let sendingMessages: [Message]    //보내는문자
     let childName: String             //자녀이름
     let schedules: [Schedule]         //상담일정
+    
+    func getMessagesWithChildName() -> [(childName: String, message: Message)] {
+        return sendingMessages.map({(childName, $0)})
+    }
 }

--- a/Gajeongtongsin/Gajeongtongsin/Screens/TabBar/TabBarViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/TabBar/TabBarViewController.swift
@@ -42,7 +42,7 @@ class TabBarViewController: UITabBarController {
              vc3 =  UINavigationController(rootViewController: ProfileViewController())
         case .teacher:
              vc1 =  UINavigationController(rootViewController: ConsultationViewController())
-             vc2 =  UINavigationController(rootViewController: ReceivingViewController())
+             vc2 =  UINavigationController(rootViewController: MessageViewController())
              vc3 =  UINavigationController(rootViewController: ProfileViewController())
         }
        

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/Cell/MessageTableViewCell.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/Cell/MessageTableViewCell.swift
@@ -1,0 +1,85 @@
+//
+//  MessageTableViewCell.swift
+//  Gajeongtongsin
+//
+//  Created by uiskim on 2022/07/23.
+//
+
+import UIKit
+
+class MessageTableViewCell: BaseTableViewCell {
+    
+    var isChecked: Bool = false {
+        didSet {
+            checkBox.tintColor = isChecked ? .red : .gray
+        }
+    }
+
+    
+    
+    static let identifier = "ProfileTableViewCell"
+    
+    let checkBox: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+    
+    let messageInfo: UILabel = {
+       let messageInfo = UILabel()
+        messageInfo.translatesAutoresizingMaskIntoConstraints = false
+        messageInfo.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
+        messageInfo.textColor = UIColor.black
+        return messageInfo
+    }()
+    
+    let content: UILabel = {
+       let content = UILabel()
+        content.translatesAutoresizingMaskIntoConstraints = false
+        content.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
+        content.textColor = UIColor.black
+        return content
+    }()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func render() {
+        contentView.addSubview(messageInfo)
+        messageInfo.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 28).isActive = true
+        messageInfo.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20).isActive = true
+        
+        contentView.addSubview(content)
+        content.topAnchor.constraint(equalTo: messageInfo.bottomAnchor, constant: 10).isActive = true
+        content.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20).isActive = true
+        
+        contentView.addSubview(checkBox)
+        checkBox.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -30).isActive = true
+        checkBox.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 40).isActive = true
+
+        
+    }
+    
+    override func configUI() {
+        checkBox.image = UIImage(systemName: "flame.fill")
+        checkBox.tintColor = .gray
+
+    }
+
+    func configure(childName: String, message: Message) {
+        if message.type != .emergency {
+            messageInfo.text = "\(childName) / \(message.type.rawValue) / \(message.expectedDate)"
+            content.text = "\(message.content)"
+        }
+    }
+    
+    func isCheck() {
+        self.isChecked.toggle()
+        
+    }
+}

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/Cell/MessageTableViewCell.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/Cell/MessageTableViewCell.swift
@@ -9,23 +9,22 @@ import UIKit
 
 class MessageTableViewCell: BaseTableViewCell {
     
-    var isChecked: Bool = false {
+    // MARK: - Properties
+    private var isChecked: Bool = false {
         didSet {
             checkBox.tintColor = isChecked ? .red : .gray
         }
     }
 
-    
-    
     static let identifier = "ProfileTableViewCell"
     
-    let checkBox: UIImageView = {
+    private let checkBox: UIImageView = {
         let imageView = UIImageView()
         imageView.translatesAutoresizingMaskIntoConstraints = false
         return imageView
     }()
     
-    let messageInfo: UILabel = {
+    private let messageInfo: UILabel = {
        let messageInfo = UILabel()
         messageInfo.translatesAutoresizingMaskIntoConstraints = false
         messageInfo.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
@@ -33,14 +32,15 @@ class MessageTableViewCell: BaseTableViewCell {
         return messageInfo
     }()
     
-    let content: UILabel = {
+    private let content: UILabel = {
        let content = UILabel()
         content.translatesAutoresizingMaskIntoConstraints = false
         content.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
         content.textColor = UIColor.black
         return content
     }()
-
+    
+    // MARK: - Init
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
     }
@@ -49,6 +49,7 @@ class MessageTableViewCell: BaseTableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // MARK: - Funcs
     override func render() {
         contentView.addSubview(messageInfo)
         messageInfo.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 28).isActive = true
@@ -78,7 +79,7 @@ class MessageTableViewCell: BaseTableViewCell {
         }
     }
     
-    func isCheck() {
+    func changeState() {
         self.isChecked.toggle()
         
     }

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/MessageVIewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/MessageVIewController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 class MessageViewController: BaseViewController {
     
+    // MARK: - Properties
     let messageList: [Message] = mainTeacher.parentUserIds.flatMap({$0.sendingMessages}).filter({$0.type != .emergency})
     
     private let tableView: UITableView = {
@@ -18,6 +19,7 @@ class MessageViewController: BaseViewController {
         return tableView
     }()
     
+    // MARK: - View Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
         tableView.dataSource = self
@@ -35,6 +37,7 @@ class MessageViewController: BaseViewController {
     
     }
     
+    // MARK: - Funcs
     func navigationBar() {
         self.navigationItem.title = "수신내역"
         self.navigationController?.navigationBar.tintColor = .black
@@ -44,18 +47,14 @@ class MessageViewController: BaseViewController {
 }
 
 
+
+
+
+
 extension MessageViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return messageList.count
     }
-    
-    
-//    func numberOfSections(in tableView: UITableView) -> Int {
-//        return mainTeacher.parentUserIds.count
-//    }
-//    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-//        return mainTeacher.parentUserIds[section].sendingMessages.count
-//    }
     
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -81,7 +80,7 @@ extension MessageViewController: UITableViewDelegate {
         let cancelAction = UIAlertAction(title: "취소", style: .cancel)
         let okayAction = UIAlertAction(title: "확인", style: .default) { _ in
             let cell = tableView.cellForRow(at: indexPath) as? MessageTableViewCell
-            cell?.isCheck()
+            cell?.changeState()
         }
         alret.addAction(cancelAction)
         alret.addAction(okayAction)

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/MessageVIewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/MessageVIewController.swift
@@ -1,0 +1,90 @@
+//
+//  MessageVIewController.swift
+//  Gajeongtongsin
+//
+//  Created by uiskim on 2022/07/23.
+//
+
+import UIKit
+
+class MessageViewController: BaseViewController {
+    
+    let messageList: [Message] = mainTeacher.parentUserIds.flatMap({$0.sendingMessages}).filter({$0.type != .emergency})
+    
+    private let tableView: UITableView = {
+        let tableView = UITableView(frame: .zero, style: .plain)
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.register(MessageTableViewCell.self, forCellReuseIdentifier: MessageTableViewCell.identifier)
+        return tableView
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        tableView.dataSource = self
+        tableView.delegate = self
+        navigationBar()
+    }
+    
+    override func render() {
+        
+        view.addSubview(tableView)
+        tableView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+        tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+        tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
+        tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
+    
+    }
+    
+    func navigationBar() {
+        self.navigationItem.title = "수신내역"
+        self.navigationController?.navigationBar.tintColor = .black
+        self.navigationController?.navigationBar.prefersLargeTitles = true
+    }
+
+}
+
+
+extension MessageViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return messageList.count
+    }
+    
+    
+//    func numberOfSections(in tableView: UITableView) -> Int {
+//        return mainTeacher.parentUserIds.count
+//    }
+//    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+//        return mainTeacher.parentUserIds[section].sendingMessages.count
+//    }
+    
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: MessageTableViewCell.identifier, for: indexPath) as? MessageTableViewCell else { return UITableViewCell()}
+        
+        let parent = mainTeacher.parentUserIds[indexPath.section]
+        
+        cell.configure(childName: parent.childName, message: messageList[indexPath.row])
+        
+        return cell
+    }
+    
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 100
+    }
+}
+
+
+extension MessageViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        let alret = UIAlertController(title: "처리완료하시겠습니까?", message: "확인을누르면 블라블라", preferredStyle: .alert)
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+        let okayAction = UIAlertAction(title: "확인", style: .default) { _ in
+            let cell = tableView.cellForRow(at: indexPath) as? MessageTableViewCell
+            cell?.isCheck()
+        }
+        alret.addAction(cancelAction)
+        alret.addAction(okayAction)
+        present(alret, animated: true, completion: nil)
+    }
+}

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/ReceivingViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/ReceivingViewController.swift
@@ -5,33 +5,33 @@
 //  Created by DaeSeong on 2022/07/16.
 //
 
-import UIKit
-
-class ReceivingViewController: BaseViewController {
-    // MARK: - Properties
-    private let textLabel: UILabel = {
-        let label = UILabel()
-        label.text = "선생님 쪽지건의 준비중입니다 😎"
-        label.font = UIFont.systemFont(ofSize: 20)
-        label.textColor = .black
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
-    }()
-    // MARK: - View Life Cycle
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-    }
-    // MARK: - Funcs
-    override func render() {
-        view.addSubview(textLabel)
-        textLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
-        textLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
-    }
-
-    override func configUI() {
-        view.backgroundColor = .primaryBackground
-    }
-    
-
-}
+//import UIKit
+//
+//class ReceivingViewController: BaseViewController {
+//    // MARK: - Properties
+//    private let textLabel: UILabel = {
+//        let label = UILabel()
+//        label.text = "선생님 쪽지건의 준비중입니다 😎"
+//        label.font = UIFont.systemFont(ofSize: 20)
+//        label.textColor = .black
+//        label.translatesAutoresizingMaskIntoConstraints = false
+//        return label
+//    }()
+//    // MARK: - View Life Cycle
+//    override func viewDidLoad() {
+//        super.viewDidLoad()
+//
+//    }
+//    // MARK: - Funcs
+//    override func render() {
+//        view.addSubview(textLabel)
+//        textLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+//        textLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
+//    }
+//
+//    override func configUI() {
+//        view.backgroundColor = .primaryBackground
+//    }
+//    
+//
+//}


### PR DESCRIPTION
## 🍏 관련 이슈
#19 

## 🍏 작업내용
 - 교사 메세지탭에서 학부모가 보낸메세지 리스트를 확인하고 해당 탭을 눌러 처리완료를 할 수 있는 페이지 구현
<p align="left">
<img width="200" alt="스크린샷 2022-07-23 오전 1 45 05" src="https://user-images.githubusercontent.com/99013115/180486162-32790167-c52d-4b38-9f48-0528854563b3.png">
<img width="200" alt="스크린샷 2022-07-23 오전 1 45 16" src="https://user-images.githubusercontent.com/99013115/180486170-19067ea3-1a3d-40ec-8260-f3c0cff1b0e6.png">
<img width="200" alt="스크린샷 2022-07-23 오전 1 45 21" src="https://user-images.githubusercontent.com/99013115/180486176-d21e6047-58c5-4d82-b162-478350d176d8.png">
</p>

## 🍏 다음으로 진행될 작업
 - [ ] 알림창(긴급메세지,일반메시지구분)구현도 추가로 완료를 해서 해당 PR merge하면 바로 알림창PR할 예정

## 🍏 주의사항
- **빈 폴더 있는지 확인하기!!**
- **파일,폴더 위치 및 이동 하지말기!!**
