### PR TITLE
[ADD] 학부모 쪽지건의 화면 업데이트 (기전송 리스트, 새로운 쪽지 발송 버튼 연결)

### DIFF
--- a/Gajeongtongsin/Gajeongtongsin.xcodeproj/project.pbxproj
+++ b/Gajeongtongsin/Gajeongtongsin.xcodeproj/project.pbxproj
@@ -39,6 +39,8 @@
 		359583A428829D99002B6873 /* TestU.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359583A328829D99002B6873 /* TestU.swift */; };
 		359583A82882A6F7002B6873 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359583A72882A6F7002B6873 /* Constants.swift */; };
 		359583AA28840415002B6873 /* TestJ.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359583A928840415002B6873 /* TestJ.swift */; };
+		8C3DD251288A63CF00A3E9C6 /* SentMessageListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C3DD250288A63CF00A3E9C6 /* SentMessageListViewController.swift */; };
+		8C40E867288B7BC100DECACA /* SentMessageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C40E866288B7BC100DECACA /* SentMessageTableViewCell.swift */; };
 		C04B547F2887C6250097EE88 /* MockData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04B547E2887C6250097EE88 /* MockData.swift */; };
 		C0DFFBFD2885DC86009A1563 /* ParentUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DFFBFC2885DC86009A1563 /* ParentUser.swift */; };
 		C0DFFC032885DE32009A1563 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DFFC022885DE32009A1563 /* Message.swift */; };
@@ -82,6 +84,8 @@
 		359583A328829D99002B6873 /* TestU.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestU.swift; sourceTree = "<group>"; };
 		359583A72882A6F7002B6873 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		359583A928840415002B6873 /* TestJ.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestJ.swift; sourceTree = "<group>"; };
+		8C3DD250288A63CF00A3E9C6 /* SentMessageListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentMessageListViewController.swift; sourceTree = "<group>"; };
+		8C40E866288B7BC100DECACA /* SentMessageTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentMessageTableViewCell.swift; sourceTree = "<group>"; };
 		C04B547E2887C6250097EE88 /* MockData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockData.swift; sourceTree = "<group>"; };
 		C0DFFBFC2885DC86009A1563 /* ParentUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentUser.swift; sourceTree = "<group>"; };
 		C0DFFC022885DE32009A1563 /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
@@ -255,6 +259,7 @@
 				3595836F288294EA002B6873 /* Cell */,
 				3595836E288294E5002B6873 /* Component */,
 				35958378288297B9002B6873 /* SendingViewController.swift */,
+				8C3DD250288A63CF00A3E9C6 /* SentMessageListViewController.swift */,
 			);
 			path = Sending;
 			sourceTree = "<group>";
@@ -341,6 +346,7 @@
 			isa = PBXGroup;
 			children = (
 				3595839028829C7B002B6873 /* TestC.swift */,
+				8C40E866288B7BC100DECACA /* SentMessageTableViewCell.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -485,6 +491,7 @@
 				3595839E28829D80002B6873 /* ProfileViewController.swift in Sources */,
 				35171CFE28828C930059F297 /* AppDelegate.swift in Sources */,
 				359583A228829D93002B6873 /* TestK.swift in Sources */,
+				8C3DD251288A63CF00A3E9C6 /* SentMessageListViewController.swift in Sources */,
 				359583732882956C002B6873 /* BaseViewController.swift in Sources */,
 				04610D952886A28C00CCCB2D /* CalenderViewCell.swift in Sources */,
 				3595838D28829C6C002B6873 /* TestA.swift in Sources */,
@@ -493,6 +500,7 @@
 				3595839328829C82002B6873 /* TestD.swift in Sources */,
 				3558AB3928868D2800539C66 /* Notification.swift in Sources */,
 				35958379288297B9002B6873 /* SendingViewController.swift in Sources */,
+				8C40E867288B7BC100DECACA /* SentMessageTableViewCell.swift in Sources */,
 				3595837F2882980C002B6873 /* StartViewController.swift in Sources */,
 				359583AA28840415002B6873 /* TestJ.swift in Sources */,
 				3595839B28829CA1002B6873 /* TestI.swift in Sources */,

--- a/Gajeongtongsin/Gajeongtongsin/Models/ParentUser.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Models/ParentUser.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct ParentUser {
     let id: String                    //유저아이디
-    let sendingMessages: [Message]    //보내는문자
+    var sendingMessages: [Message]    //보내는문자
     let childName: String             //자녀이름
     let schedules: [Schedule]         //상담일정
 }

--- a/Gajeongtongsin/Gajeongtongsin/Models/TeacherUser.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Models/TeacherUser.swift
@@ -8,6 +8,6 @@
 import Foundation
 struct TeacherUser {
     let teacherName: String             //교사이름
-    let parentUserIds: [ParentUser]     //교사가 담당해야할 학부모 ->파베할떈 String
+    var parentUserIds: [ParentUser]     //교사가 담당해야할 학부모 ->파베할떈 String
     //let parentUsers: [ParentUser]     //이게 맞지 않나...?
 }

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/Cell/SentMessageTableViewCell.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/Cell/SentMessageTableViewCell.swift
@@ -12,6 +12,10 @@ class sentMessageTableViewCell: BaseTableViewCell {
     //MARK: - Properties
     static let identifier = "SentMessageTableViewCell"
     
+    var currentParent: ParentUser {
+        return mainTeacher.parentUserIds[0]
+    }
+    
     let messageInfo: UILabel = {
        let messageInfo = UILabel()
         messageInfo.translatesAutoresizingMaskIntoConstraints = false
@@ -51,8 +55,25 @@ class sentMessageTableViewCell: BaseTableViewCell {
     
     override func configUI() {
         checkIndicator.image = UIImage(systemName: "checkmark.square")
+        
+        
     }
     
+    
+    
+    func configure(index: Int) {
+        
+        func msgType() -> String {
+            switch currentParent.sendingMessages[index].type {
+                case .absence : return "결석"
+                case .earlyLeave : return "조퇴"
+            }
+        }
+        
+        messageInfo.text = "\(currentParent.childName) / \(msgType()) / \(currentParent.sendingMessages[index].expectedDate)"
+        
+        content.text = "\(currentParent.sendingMessages[index].content)"
+    }
 //    func cellTextMap(parent: ParentUser, message: Message) {
 //        messageInfo.text = "\(parent.childName) / \(message.type) / \(message.expectedDate)"
 //        content.text = "\(message.content)"

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/Cell/SentMessageTableViewCell.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/Cell/SentMessageTableViewCell.swift
@@ -1,0 +1,62 @@
+//
+//  SentMessageTableViewCell.swift
+//  Gajeongtongsin
+//
+//  Created by Youngwoong Choi on 2022/07/23.
+//
+
+import UIKit
+
+class sentMessageTableViewCell: BaseTableViewCell {
+    
+    static let identifier = "ProfileTableViewCell"
+    
+    
+    let messageInfo: UILabel = {
+       let messageInfo = UILabel()
+        messageInfo.translatesAutoresizingMaskIntoConstraints = false
+        messageInfo.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
+        messageInfo.textColor = UIColor.black
+        return messageInfo
+    }()
+
+    let content: UILabel = {
+       let content = UILabel()
+        content.translatesAutoresizingMaskIntoConstraints = false
+        content.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
+        content.textColor = UIColor.black
+        return content
+    }()
+    
+    let checkIndicator: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+    
+    
+    override func render() {
+        contentView.addSubview(messageInfo)
+        messageInfo.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 28).isActive = true
+        messageInfo.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20).isActive = true
+
+        contentView.addSubview(content)
+        content.topAnchor.constraint(equalTo: messageInfo.bottomAnchor, constant: 10).isActive = true
+        content.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20).isActive = true
+
+        contentView.addSubview(checkIndicator)
+        checkIndicator.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -30).isActive = true
+        checkIndicator.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 40).isActive = true
+    }
+    
+    override func configUI() {
+        
+    }
+    
+//    func configure(childName: String, message: Message) {
+//        if message.type != .emergency {
+//            messageInfo.text = "\(childName) / \(message.type) / \(message.expectedDate)"
+//            content.text = "\(message.content)"
+//        }
+//    }
+}

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/Cell/SentMessageTableViewCell.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/Cell/SentMessageTableViewCell.swift
@@ -11,7 +11,6 @@ class sentMessageTableViewCell: BaseTableViewCell {
     
     static let identifier = "SentMessageTableViewCell"
     
-    
     let messageInfo: UILabel = {
        let messageInfo = UILabel()
         messageInfo.translatesAutoresizingMaskIntoConstraints = false
@@ -34,7 +33,6 @@ class sentMessageTableViewCell: BaseTableViewCell {
         return imageView
     }()
     
-    
     override func render() {
         contentView.addSubview(messageInfo)
         messageInfo.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 28).isActive = true
@@ -50,13 +48,12 @@ class sentMessageTableViewCell: BaseTableViewCell {
     }
     
     override func configUI() {
-        
+        checkIndicator.image = UIImage(systemName: "checkmark.square")
     }
     
-//    func configure(childName: String, message: Message) {
-//        if message.type != .emergency {
-//            messageInfo.text = "\(childName) / \(message.type) / \(message.expectedDate)"
-//            content.text = "\(message.content)"
-//        }
+//    func cellTextMap(parent: ParentUser, message: Message) {
+//        messageInfo.text = "\(parent.childName) / \(message.type) / \(message.expectedDate)"
+//        content.text = "\(message.content)"
 //    }
 }
+

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/Cell/SentMessageTableViewCell.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/Cell/SentMessageTableViewCell.swift
@@ -9,7 +9,7 @@ import UIKit
 
 class sentMessageTableViewCell: BaseTableViewCell {
     
-    static let identifier = "ProfileTableViewCell"
+    static let identifier = "SentMessageTableViewCell"
     
     
     let messageInfo: UILabel = {

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/Cell/SentMessageTableViewCell.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/Cell/SentMessageTableViewCell.swift
@@ -9,6 +9,7 @@ import UIKit
 
 class sentMessageTableViewCell: BaseTableViewCell {
     
+    //MARK: - Properties
     static let identifier = "SentMessageTableViewCell"
     
     let messageInfo: UILabel = {
@@ -27,12 +28,13 @@ class sentMessageTableViewCell: BaseTableViewCell {
         return content
     }()
     
-    let checkIndicator: UIImageView = {
+    private let checkIndicator: UIImageView = {
         let imageView = UIImageView()
         imageView.translatesAutoresizingMaskIntoConstraints = false
         return imageView
     }()
     
+    //MARK: - Funcs
     override func render() {
         contentView.addSubview(messageInfo)
         messageInfo.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 28).isActive = true

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SendingViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SendingViewController.swift
@@ -27,7 +27,7 @@ class SendingViewController: BaseViewController {
     }()
     private let textLabelDate: UILabel = {
         let label = UILabel()
-//        label.isHidden = true
+        label.isHidden = true
         label.text = "일시"
         label.font = UIFont.systemFont(ofSize: 18, weight: .bold)
         label.textColor = .black
@@ -36,7 +36,7 @@ class SendingViewController: BaseViewController {
     }()
     private let textLabelReason: UILabel = {
         let label = UILabel()
-//        label.isHidden = true
+        label.isHidden = true
         label.text = "사유"
         label.font = UIFont.systemFont(ofSize: 18, weight: .bold)
         label.textColor = .black
@@ -66,6 +66,7 @@ class SendingViewController: BaseViewController {
     //메시지 내용 전송 버튼
     private let sendButton: UIButton = {
         let button = UIButton()
+        button.isHidden = true
         button.setTitle("전송", for: .normal)
         button.setTitleColor(UIColor.white, for: .normal)
         button.backgroundColor = .systemBlue
@@ -77,26 +78,25 @@ class SendingViewController: BaseViewController {
         return button
     }()
     
-    //MARK: - Propoerties
     //Date 입력 관련
     //TODO: -
     //messagetype 에서 결석을 선택할 때와 조퇴를 선택할 때 pickermode 변경
     private let datePicker: UIDatePicker = {
         let picker = UIDatePicker()
-//        picker.isHidden = true
+        picker.isHidden = true
         picker.preferredDatePickerStyle = .compact
         picker.locale = Locale(identifier: "ko-KR")
+        picker.minuteInterval = 15
         picker.translatesAutoresizingMaskIntoConstraints = false
         return picker
     }()
     
-    //MARK: - Properties
     //사유 입력하는 Text Field View
     //TODO: -
     //Text Field 내 여백 padding 값 조절, 글자수 제한, 박스 외부 클릭했을 때 커서와 키보드 사라지게 등등
     private let textFieldForReason: UITextField = {
         let textF = UITextField()
-//        textF.isHidden = true
+        textF.isHidden = true
         textF.text = "기본텍스트입니다"
         textF.textColor = .black
         textF.font = .systemFont(ofSize: 17, weight: .medium)
@@ -110,8 +110,7 @@ class SendingViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         textFieldForReason.delegate = self
-
-
+        sendButton.addTarget(self, action: #selector(sendMessage), for: .touchUpInside)
     }
     //MARK: - Funcs
     override func render() {
@@ -164,20 +163,45 @@ class SendingViewController: BaseViewController {
         messageTypeButton.menu = UIMenu(options: .displayInline, children: [
             UIAction(title: "결석", handler: { _ in
                 self.messageTypeButton.setTitle("결석", for: .normal)
-//                self.textLabelDate.isHidden = false
-//                self.datePicker.isHidden = false
+                self.textLabelDate.isHidden = false
+                self.datePicker.isHidden = false
                 self.datePicker.datePickerMode = .date
-                print("결석 누름")
+                self.textLabelReason.isHidden = false
+                self.textFieldForReason.isHidden = false
+                self.sendButton.isHidden = false
             }),
             UIAction(title: "조퇴", handler: { _ in
                 self.messageTypeButton.setTitle("조퇴", for: .normal)
-//                self.textLabelDate.isHidden = false
-//                self.datePicker.isHidden = false
+                self.textLabelDate.isHidden = false
+                self.datePicker.isHidden = false
                 self.datePicker.datePickerMode = .dateAndTime
-                print("조퇴 누름")                
+                self.textLabelReason.isHidden = false
+                self.textFieldForReason.isHidden = false
+                self.sendButton.isHidden = false
             })
         ])
         
+        //프로퍼티 옵저버 구현 고려 중 (날짜, 시간 값이 세팅되어야 사유 입력창 등장)
+//        var dateObserver: Date = datePicker.date {
+//            didSet {
+//                self.textLabelReason.isHidden = false
+//                self.textFieldForReason.isHidden = false
+//            }
+//        }
+    }
+    
+    func msgType() -> MessageType {
+        let msgType = messageTypeButton.currentTitle == "결석" ? MessageType.absence : MessageType.earlyLeave
+        return msgType
+    }
+  
+    @objc func sendMessage() {
+        let newMsg = Message(type: msgType(),
+                             sentDate: Date(),
+                             expectedDate: "\(datePicker.date)",
+                             content: textFieldForReason.text ?? "",
+                             isCompleted: false)
+        messageList1.append(newMsg)
     }
 }
 

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SendingViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SendingViewController.swift
@@ -7,9 +7,15 @@
 
 import UIKit
 
+protocol SendingViewControllerDelegate: AnyObject {
+    func reloadTable()
+}
+
 class SendingViewController: BaseViewController {
     
     //MARK: - Properties
+    weak var delegate: SendingViewControllerDelegate?
+    
     var currentParent: ParentUser {
         return mainTeacher.parentUserIds[0]
     }
@@ -205,7 +211,8 @@ class SendingViewController: BaseViewController {
                              expectedDate: "\(datePicker.date)",
                              content: textFieldForReason.text ?? "",
                              isCompleted: false)
-//        currentParent.sendingMessages.append(newMsg)
+        mainTeacher.parentUserIds[0].sendingMessages.append(newMsg)
+        delegate?.reloadTable()
         
         //작동 안한다...
         //전송버튼 누를 때 리스트 뷰가 갱신 되어야 하는데 지금은 처음 로드한 리스트 그대로...

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SendingViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SendingViewController.swift
@@ -8,9 +8,12 @@
 import UIKit
 
 class SendingViewController: BaseViewController {
-    private var currentParent = parent1
     
     //MARK: - Properties
+    var currentParent: ParentUser {
+        return mainTeacher.parentUserIds[0]
+    }
+    
     //Text Labels (Switch 구문 써서 더 줄일 수 있을지?)
     private let textLabelPurpose: UILabel = {
         let label = UILabel()
@@ -74,14 +77,12 @@ class SendingViewController: BaseViewController {
     }()
     
     //Date 입력 관련
-    //TODO: -
-    //messagetype 에서 결석을 선택할 때와 조퇴를 선택할 때 pickermode 변경
     private let datePicker: UIDatePicker = {
         let picker = UIDatePicker()
         picker.isHidden = true
         picker.preferredDatePickerStyle = .compact
         picker.locale = Locale(identifier: "ko-KR")
-        picker.minuteInterval = 15
+        picker.minuteInterval = 30
         picker.translatesAutoresizingMaskIntoConstraints = false
         return picker
     }()
@@ -93,7 +94,7 @@ class SendingViewController: BaseViewController {
     private let textFieldForReason: UITextField = {
         let textF = UITextField()
         textF.isHidden = true
-        textF.text = "기본텍스트입니다"
+        textF.placeholder = "기본텍스트입니다"
         textF.textColor = .black
         textF.font = .systemFont(ofSize: 17, weight: .medium)
         textF.backgroundColor = .secondarySystemFill
@@ -107,13 +108,15 @@ class SendingViewController: BaseViewController {
         super.viewDidLoad()
         textFieldForReason.delegate = self
         sendButton.addTarget(self, action: #selector(sendMessage), for: .touchUpInside)
+        navigationBar()
     }
+    
     //MARK: - Funcs
     override func render() {
 
         view.addSubview(textLabelPurpose)
         textLabelPurpose.heightAnchor.constraint(equalToConstant: 40).isActive = true
-        textLabelPurpose.topAnchor.constraint(equalTo: view.topAnchor, constant: 20).isActive = true
+        textLabelPurpose.topAnchor.constraint(equalTo: view.topAnchor, constant: 100).isActive = true
         textLabelPurpose.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20).isActive = true
         
         view.addSubview(messageTypeButton)
@@ -157,23 +160,23 @@ class SendingViewController: BaseViewController {
         
         //Message Type 버튼과 선택에 따른 컴포넌트 노출 차이
         messageTypeButton.menu = UIMenu(options: .displayInline, children: [
-            UIAction(title: "결석", handler: { _ in
-                self.messageTypeButton.setTitle("결석", for: .normal)
-                self.textLabelDate.isHidden = false
-                self.datePicker.isHidden = false
-                self.datePicker.datePickerMode = .date
-                self.textLabelReason.isHidden = false
-                self.textFieldForReason.isHidden = false
-                self.sendButton.isHidden = false
+            UIAction(title: "결석", handler: { [weak self] _ in
+                self?.messageTypeButton.setTitle("결석", for: .normal)
+                self?.textLabelDate.isHidden = false
+                self?.datePicker.isHidden = false
+                self?.datePicker.datePickerMode = .date
+                self?.textLabelReason.isHidden = false
+                self?.textFieldForReason.isHidden = false
+                self?.sendButton.isHidden = false
             }),
-            UIAction(title: "조퇴", handler: { _ in
-                self.messageTypeButton.setTitle("조퇴", for: .normal)
-                self.textLabelDate.isHidden = false
-                self.datePicker.isHidden = false
-                self.datePicker.datePickerMode = .dateAndTime
-                self.textLabelReason.isHidden = false
-                self.textFieldForReason.isHidden = false
-                self.sendButton.isHidden = false
+            UIAction(title: "조퇴", handler: { [weak self] _ in
+                self?.messageTypeButton.setTitle("조퇴", for: .normal)
+                self?.textLabelDate.isHidden = false
+                self?.datePicker.isHidden = false
+                self?.datePicker.datePickerMode = .dateAndTime
+                self?.textLabelReason.isHidden = false
+                self?.textFieldForReason.isHidden = false
+                self?.sendButton.isHidden = false
             })
         ])
         
@@ -184,6 +187,11 @@ class SendingViewController: BaseViewController {
 //                self.textFieldForReason.isHidden = false
 //            }
 //        }
+    }
+    
+    func navigationBar() {
+        self.navigationItem.title = "문자작성"
+        self.navigationItem.leftBarButtonItem = UIBarButtonItem(systemItem: .cancel)
     }
     
     func msgType() -> MessageType {
@@ -197,11 +205,11 @@ class SendingViewController: BaseViewController {
                              expectedDate: "\(datePicker.date)",
                              content: textFieldForReason.text ?? "",
                              isCompleted: false)
-        currentParent.sendingMessages.append(newMsg)
-        print(currentParent.sendingMessages)
-        //전송버튼 누를 때 리스트 뷰가 갱신 되어야 하는데 지금은 처음 로드한 리스트 그대로..
-        let vc = SentMessageListViewController()
-        vc.viewDidLoad()
+//        currentParent.sendingMessages.append(newMsg)
+        
+        //작동 안한다...
+        //전송버튼 누를 때 리스트 뷰가 갱신 되어야 하는데 지금은 처음 로드한 리스트 그대로...
+        
         dismiss(animated: true)
     }
 }

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SendingViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SendingViewController.swift
@@ -10,6 +10,12 @@ import UIKit
 class SendingViewController: BaseViewController {
     
     //MARK: - Properties
+//    let messageFromParent: Message = {
+//        let msg = Message()
+//        msg.isCompleted = false
+//        msg.sentDate = Date()
+//    }()
+    
     //Text Labels (Switch 구문 써서 더 줄일 수 있을지?)
     private let textLabelPurpose: UILabel = {
         let label = UILabel()
@@ -57,6 +63,20 @@ class SendingViewController: BaseViewController {
         return button
     }()
     
+    //메시지 내용 전송 버튼
+    private let sendButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("전송", for: .normal)
+        button.setTitleColor(UIColor.white, for: .normal)
+        button.backgroundColor = .systemBlue
+        button.titleLabel?.font = UIFont.systemFont(ofSize: 17, weight: .medium)
+        button.layer.borderWidth = 0
+        button.layer.borderColor = UIColor.systemBlue.cgColor
+        button.layer.cornerRadius = 10
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+    
     //MARK: - Propoerties
     //Date 입력 관련
     //TODO: -
@@ -98,7 +118,7 @@ class SendingViewController: BaseViewController {
 
         view.addSubview(textLabelPurpose)
         textLabelPurpose.heightAnchor.constraint(equalToConstant: 40).isActive = true
-        textLabelPurpose.topAnchor.constraint(equalTo: view.topAnchor, constant: 100).isActive = true
+        textLabelPurpose.topAnchor.constraint(equalTo: view.topAnchor, constant: 20).isActive = true
         textLabelPurpose.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20).isActive = true
         
         view.addSubview(messageTypeButton)
@@ -128,6 +148,13 @@ class SendingViewController: BaseViewController {
         textFieldForReason.heightAnchor.constraint(equalToConstant: 40).isActive = true
         textFieldForReason.widthAnchor.constraint(equalToConstant: 350).isActive = true
         textFieldForReason.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20).isActive = true
+        
+        view.addSubview(sendButton)
+        sendButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -100).isActive = true
+        sendButton.heightAnchor.constraint(equalToConstant: 40).isActive = true
+        sendButton.widthAnchor.constraint(equalToConstant: 350).isActive = true
+        sendButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20).isActive = true
+
     }
 
     override func configUI() {
@@ -147,7 +174,7 @@ class SendingViewController: BaseViewController {
 //                self.textLabelDate.isHidden = false
 //                self.datePicker.isHidden = false
                 self.datePicker.datePickerMode = .dateAndTime
-                print("조퇴 누름")
+                print("조퇴 누름")                
             })
         ])
         

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SendingViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SendingViewController.swift
@@ -8,14 +8,9 @@
 import UIKit
 
 class SendingViewController: BaseViewController {
+    private var currentParent = parent1
     
     //MARK: - Properties
-//    let messageFromParent: Message = {
-//        let msg = Message()
-//        msg.isCompleted = false
-//        msg.sentDate = Date()
-//    }()
-    
     //Text Labels (Switch 구문 써서 더 줄일 수 있을지?)
     private let textLabelPurpose: UILabel = {
         let label = UILabel()
@@ -90,6 +85,7 @@ class SendingViewController: BaseViewController {
         picker.translatesAutoresizingMaskIntoConstraints = false
         return picker
     }()
+    
     
     //사유 입력하는 Text Field View
     //TODO: -
@@ -182,7 +178,7 @@ class SendingViewController: BaseViewController {
         ])
         
         //프로퍼티 옵저버 구현 고려 중 (날짜, 시간 값이 세팅되어야 사유 입력창 등장)
-//        var dateObserver: Date = datePicker.date {
+//        var selectedDate: Date = datePicker.date {
 //            didSet {
 //                self.textLabelReason.isHidden = false
 //                self.textFieldForReason.isHidden = false
@@ -201,7 +197,12 @@ class SendingViewController: BaseViewController {
                              expectedDate: "\(datePicker.date)",
                              content: textFieldForReason.text ?? "",
                              isCompleted: false)
-        messageList1.append(newMsg)
+        currentParent.sendingMessages.append(newMsg)
+        print(currentParent.sendingMessages)
+        //전송버튼 누를 때 리스트 뷰가 갱신 되어야 하는데 지금은 처음 로드한 리스트 그대로..
+        let vc = SentMessageListViewController()
+        vc.viewDidLoad()
+        dismiss(animated: true)
     }
 }
 

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SentMessageListViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SentMessageListViewController.swift
@@ -12,6 +12,10 @@ class SentMessageListViewController: BaseViewController {
     let messageList: [Message] = mainTeacher.parentUserIds.flatMap({$0.sendingMessages})
 //        .filter({$0.type != .emergency})
     
+    //화면에 뿌려줄 메시지 리스트를 곧바로 'messageList#'으로 지정하지 않고, 부모 유저(여기선 parent1)에 속한 것으로 불러옴
+    let currentParent = parent1
+
+    
     private let viewTitle: UILabel = {
         let label = UILabel()
         label.text = "전송내역"
@@ -32,7 +36,8 @@ class SentMessageListViewController: BaseViewController {
     
     private let sentMessageList: UITableView = {
         let table = UITableView(frame: .zero, style: .plain)
-        table.register(UITableViewCell.self, forCellReuseIdentifier: sentMessageTableViewCell.identifier)
+        table.register(sentMessageTableViewCell.self, forCellReuseIdentifier: sentMessageTableViewCell.identifier)
+        table.rowHeight = 100
         table.translatesAutoresizingMaskIntoConstraints = false
         return table
     }()
@@ -47,21 +52,6 @@ class SentMessageListViewController: BaseViewController {
     
     //MARK: - Funcs
     override func render() {
-//        view.addSubview(navigationBar)
-//        navigationBar.topAnchor.constraint(equalTo: view.topAnchor, constant: 100).isActive = true
-//        navigationBar.heightAnchor.constraint(equalToConstant: 50).isActive = true
-        
-//        view.addSubview(viewTitle)
-//        viewTitle.topAnchor.constraint(equalTo: view.topAnchor, constant: 100).isActive = true
-//        viewTitle.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20).isActive = true
-//        viewTitle.heightAnchor.constraint(equalToConstant: 50).isActive = true
-//
-//        view.addSubview(writeMessageButton)
-//        writeMessageButton.heightAnchor.constraint(equalToConstant: 40).isActive = true
-//        writeMessageButton.widthAnchor.constraint(equalToConstant: 40).isActive = true
-//        writeMessageButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 100).isActive = true
-//        writeMessageButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20).isActive = true
-        
         view.addSubview(sentMessageList)
         sentMessageList.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
         sentMessageList.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
@@ -92,17 +82,30 @@ extension SentMessageListViewController: UITableViewDelegate {
 
 extension SentMessageListViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return messageList.count
+        return currentParent.sendingMessages.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: sentMessageTableViewCell.identifier, for: indexPath)
+        let cell = tableView.dequeueReusableCell(withIdentifier: "SentMessageTableViewCell", for: indexPath) as! sentMessageTableViewCell
         
-        let parent = mainTeacher.parentUserIds[indexPath.section]
+        let messagesToView = currentParent.sendingMessages[indexPath.row]
+        
+        func msgType() -> String {
+            switch messagesToView.type {
+                case .absence : return "결석"
+                case .earlyLeave : return "조퇴"
+            case .emergency : return "긴급"
+            }
+        }
+        
+        cell.messageInfo.text = "\(currentParent.childName) / \(msgType()) / \(messagesToView.expectedDate)"
+        
+        cell.content.text = "\(messagesToView.content)"
 
-//        cell.configure(childName: parent.childName, message: messageList[indexPath.row])
-
-        cell.imageView?.image = UIImage(systemName: "plus")
         return cell
     }
 }
+
+
+
+

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SentMessageListViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SentMessageListViewController.swift
@@ -9,9 +9,9 @@ import UIKit
 
 class SentMessageListViewController: BaseViewController {
     //MARK: - Properties
-    let messageList: [Message] = mainTeacher.parentUserIds.flatMap({$0.sendingMessages})
-//        .filter({$0.type != .emergency})
-    
+//    let messageList: [Message] = mainTeacher.parentUserIds.flatMap({$0.sendingMessages})
+////        .filter({$0.type != .emergency})
+//
     //화면에 뿌려줄 메시지 리스트를 곧바로 'messageList#'으로 지정하지 않고, 부모 유저(여기선 parent1)에 속한 것으로 불러옴
     
     var currentParent: ParentUser {
@@ -51,6 +51,7 @@ class SentMessageListViewController: BaseViewController {
         super.viewDidLoad()
         sentMessageList.delegate = self
         sentMessageList.dataSource = self
+
         navigationBar()
         writeMessageButton.addTarget(self, action: #selector(writeButton), for: .touchUpInside)
     }
@@ -78,10 +79,13 @@ class SentMessageListViewController: BaseViewController {
         let vc = SendingViewController()
         vc.modalPresentationStyle = UIModalPresentationStyle.popover
         vc.modalTransitionStyle = UIModalTransitionStyle.coverVertical
+        vc.delegate = self
         present(vc, animated: true)
     }
-    
+   
 }
+
+//MARK: - Extensions
 
 extension SentMessageListViewController: UITableViewDelegate {
     
@@ -95,19 +99,16 @@ extension SentMessageListViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "SentMessageTableViewCell", for: indexPath) as! sentMessageTableViewCell
         
-        let messagesToView = currentParent.sendingMessages[indexPath.row]
-        
-        func msgType() -> String {
-            switch messagesToView.type {
-                case .absence : return "결석"
-                case .earlyLeave : return "조퇴"
-            }
-        }
-        
-        cell.messageInfo.text = "\(currentParent.childName) / \(msgType()) / \(messagesToView.expectedDate)"
-        
-        cell.content.text = "\(messagesToView.content)"
+        cell.configure(index: indexPath.row)
 
         return cell
+    }
+}
+
+
+
+extension SentMessageListViewController: SendingViewControllerDelegate {
+    func reloadTable() {
+        sentMessageList.reloadData()
     }
 }

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SentMessageListViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SentMessageListViewController.swift
@@ -1,0 +1,109 @@
+//
+//  SentMessageListViewController.swift
+//  Gajeongtongsin
+//
+//  Created by Youngwoong Choi on 2022/07/22.
+//
+
+import UIKit
+
+class SentMessageListViewController: BaseViewController {
+    //MARK: - Properties
+    let messageList: [Message] = mainTeacher.parentUserIds.flatMap({$0.sendingMessages}).filter({$0.type != .emergency})
+    
+    private let viewTitle: UILabel = {
+        let label = UILabel()
+        label.text = "전송내역"
+        label.font = UIFont.systemFont(ofSize: 28, weight: .bold)
+        label.textColor = .black
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private let writeMessageButton: UIButton = {
+        let btn = UIButton()
+        btn.setImage(UIImage(systemName: "plus.message"), for: .normal)
+        btn.setTitleColor(UIColor.black, for: .normal)
+        btn.titleLabel?.font = UIFont.systemFont(ofSize: 40, weight: .bold)
+        btn.translatesAutoresizingMaskIntoConstraints = false
+        return btn
+    }()
+    
+    private let sentMessageList: UITableView = {
+        let table = UITableView(frame: .zero, style: .plain)
+        table.register(UITableViewCell.self, forCellReuseIdentifier: sentMessageTableViewCell.identifier)
+        table.translatesAutoresizingMaskIntoConstraints = false
+        return table
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        sentMessageList.delegate = self
+        sentMessageList.dataSource = self
+        navigationBar()
+        writeMessageButton.addTarget(self, action: #selector(writeButton), for: .touchUpInside)
+    }
+    
+    //MARK: - Funcs
+    override func render() {
+//        view.addSubview(navigationBar)
+//        navigationBar.topAnchor.constraint(equalTo: view.topAnchor, constant: 100).isActive = true
+//        navigationBar.heightAnchor.constraint(equalToConstant: 50).isActive = true
+        
+//        view.addSubview(viewTitle)
+//        viewTitle.topAnchor.constraint(equalTo: view.topAnchor, constant: 100).isActive = true
+//        viewTitle.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20).isActive = true
+//        viewTitle.heightAnchor.constraint(equalToConstant: 50).isActive = true
+//
+//        view.addSubview(writeMessageButton)
+//        writeMessageButton.heightAnchor.constraint(equalToConstant: 40).isActive = true
+//        writeMessageButton.widthAnchor.constraint(equalToConstant: 40).isActive = true
+//        writeMessageButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 100).isActive = true
+//        writeMessageButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20).isActive = true
+        
+        view.addSubview(sentMessageList)
+        sentMessageList.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+        sentMessageList.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+        sentMessageList.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
+        sentMessageList.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
+    }
+    
+    override func configUI() {
+        view.backgroundColor = .primaryBackground
+//        navigationBar.delegate = self
+    }
+    
+    func navigationBar() {
+//        self.navigationItem.title = "전송내역nav"
+        self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: viewTitle)
+        self.navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "plus.message"), style: .plain, target: self, action: #selector(writeButton))
+    }
+    
+    @objc func writeButton() {
+        let vc = SendingViewController()
+        present(vc, animated: true)
+    }
+}
+
+extension SentMessageListViewController: UITableViewDelegate {
+    
+}
+
+extension SentMessageListViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return messageList.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: sentMessageTableViewCell.identifier, for: indexPath)
+        
+        let parent = mainTeacher.parentUserIds[indexPath.section]
+
+//        cell.configure(childName: parent.childName, message: messageList[indexPath.row])
+
+        cell.imageView?.image = UIImage(systemName: "plus")
+        return cell
+    }
+    
+    
+}

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SentMessageListViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SentMessageListViewController.swift
@@ -9,7 +9,8 @@ import UIKit
 
 class SentMessageListViewController: BaseViewController {
     //MARK: - Properties
-    let messageList: [Message] = mainTeacher.parentUserIds.flatMap({$0.sendingMessages}).filter({$0.type != .emergency})
+    let messageList: [Message] = mainTeacher.parentUserIds.flatMap({$0.sendingMessages})
+//        .filter({$0.type != .emergency})
     
     private let viewTitle: UILabel = {
         let label = UILabel()
@@ -104,6 +105,4 @@ extension SentMessageListViewController: UITableViewDataSource {
         cell.imageView?.image = UIImage(systemName: "plus")
         return cell
     }
-    
-    
 }

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SentMessageListViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SentMessageListViewController.swift
@@ -13,7 +13,10 @@ class SentMessageListViewController: BaseViewController {
 //        .filter({$0.type != .emergency})
     
     //화면에 뿌려줄 메시지 리스트를 곧바로 'messageList#'으로 지정하지 않고, 부모 유저(여기선 parent1)에 속한 것으로 불러옴
-    let currentParent = parent1
+    
+    var currentParent: ParentUser {
+        return mainTeacher.parentUserIds[0]
+    }
 
     
     private let viewTitle: UILabel = {
@@ -34,7 +37,7 @@ class SentMessageListViewController: BaseViewController {
         return btn
     }()
     
-    private let sentMessageList: UITableView = {
+    let sentMessageList: UITableView = {
         let table = UITableView(frame: .zero, style: .plain)
         table.register(sentMessageTableViewCell.self, forCellReuseIdentifier: sentMessageTableViewCell.identifier)
         table.rowHeight = 100
@@ -42,6 +45,8 @@ class SentMessageListViewController: BaseViewController {
         return table
     }()
     
+    
+    //MARK: - View Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
         sentMessageList.delegate = self
@@ -61,7 +66,6 @@ class SentMessageListViewController: BaseViewController {
     
     override func configUI() {
         view.backgroundColor = .primaryBackground
-//        navigationBar.delegate = self
     }
     
     func navigationBar() {
@@ -72,8 +76,11 @@ class SentMessageListViewController: BaseViewController {
     
     @objc func writeButton() {
         let vc = SendingViewController()
+        vc.modalPresentationStyle = UIModalPresentationStyle.popover
+        vc.modalTransitionStyle = UIModalTransitionStyle.coverVertical
         present(vc, animated: true)
     }
+    
 }
 
 extension SentMessageListViewController: UITableViewDelegate {
@@ -94,7 +101,6 @@ extension SentMessageListViewController: UITableViewDataSource {
             switch messagesToView.type {
                 case .absence : return "결석"
                 case .earlyLeave : return "조퇴"
-            case .emergency : return "긴급"
             }
         }
         
@@ -105,7 +111,3 @@ extension SentMessageListViewController: UITableViewDataSource {
         return cell
     }
 }
-
-
-
-

--- a/Gajeongtongsin/Gajeongtongsin/Screens/TabBar/TabBarViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/TabBar/TabBarViewController.swift
@@ -38,7 +38,7 @@ class TabBarViewController: UITabBarController {
         switch role {
         case .parent:
              vc1 =  UINavigationController(rootViewController: ReservationViewController())
-             vc2 =  UINavigationController(rootViewController: SendingViewController())
+             vc2 =  UINavigationController(rootViewController: SentMessageListViewController())
              vc3 =  UINavigationController(rootViewController: ProfileViewController())
         case .teacher:
              vc1 =  UINavigationController(rootViewController: ConsultationViewController())


### PR DESCRIPTION
- MockData 연결이 잘 되지 않아 추가로 작업 예정
- NavBar Item 방식으로 뷰 타이틀 생성


## 🍏 관련 이슈
#7 

## 🍏 작업내용
<img width="354" alt="image" src="https://user-images.githubusercontent.com/103012800/180589612-6975b5e4-87f0-4125-9149-204e2460ac00.png">
MockData 연결 실패하여 우선 테이블 리스트만 삽입

<img width="354" alt="image" src="https://user-images.githubusercontent.com/103012800/180589632-5afe59e0-bc74-4b51-91cb-002e4cf9f2b0.png">
우상단 버튼 클릭 시 새로운 메시지 전송 뷰 팝업

## 🍏 다음으로 진행될 작업
 - [x] MockData 연결
 - [x] Data 불러와서 전송 리스트에 뿌려주기
 - [x] 신규 메시지 전송 시 Mock Data 에 임시로 추가되고, 전송 리스트에도 생성 기능 구현
 - [ ] 학부모 캘린더 뷰 UI 작업

## 🍏 주의사항
- **빈 폴더 있는지 확인하기!!**
- **파일,폴더 위치 및 이동 하지말기!!**
