### PR TITLE
[ADD] 교사 캘린더뷰 일부 구현 - 학부모별/전체 상담예약 표시

### DIFF
--- a/Gajeongtongsin/Gajeongtongsin.xcodeproj/project.pbxproj
+++ b/Gajeongtongsin/Gajeongtongsin.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		045D0DBE2888DDB700778EEC /* ParentsCalenderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 045D0DBD2888DDB700778EEC /* ParentsCalenderViewController.swift */; };
 		04610D9328868C5E00CCCB2D /* BaseCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04610D9228868C5E00CCCB2D /* BaseCollectionViewCell.swift */; };
 		04610D952886A28C00CCCB2D /* CalenderViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04610D942886A28C00CCCB2D /* CalenderViewCell.swift */; };
+		04797679288E7855009C0826 /* teacherCalenderData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04797678288E7855009C0826 /* teacherCalenderData.swift */; };
 		35171CFE28828C930059F297 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35171CFD28828C930059F297 /* AppDelegate.swift */; };
 		35171D0028828C930059F297 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35171CFF28828C930059F297 /* SceneDelegate.swift */; };
 		35171D0728828C930059F297 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 35171D0628828C930059F297 /* Assets.xcassets */; };
@@ -39,7 +40,6 @@
 		359583A228829D93002B6873 /* TestK.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359583A128829D93002B6873 /* TestK.swift */; };
 		359583A428829D99002B6873 /* TestU.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359583A328829D99002B6873 /* TestU.swift */; };
 		359583A82882A6F7002B6873 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359583A72882A6F7002B6873 /* Constants.swift */; };
-		359583AA28840415002B6873 /* TestJ.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359583A928840415002B6873 /* TestJ.swift */; };
 		C04B547F2887C6250097EE88 /* MockData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04B547E2887C6250097EE88 /* MockData.swift */; };
 		C0DFFBFD2885DC86009A1563 /* ParentUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DFFBFC2885DC86009A1563 /* ParentUser.swift */; };
 		C0DFFC032885DE32009A1563 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DFFC022885DE32009A1563 /* Message.swift */; };
@@ -52,6 +52,7 @@
 		045D0DBD2888DDB700778EEC /* ParentsCalenderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentsCalenderViewController.swift; sourceTree = "<group>"; };
 		04610D9228868C5E00CCCB2D /* BaseCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCollectionViewCell.swift; sourceTree = "<group>"; };
 		04610D942886A28C00CCCB2D /* CalenderViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalenderViewCell.swift; sourceTree = "<group>"; };
+		04797678288E7855009C0826 /* teacherCalenderData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = teacherCalenderData.swift; sourceTree = "<group>"; };
 		35171CFA28828C930059F297 /* Gajeongtongsin.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Gajeongtongsin.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		35171CFD28828C930059F297 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		35171CFF28828C930059F297 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -83,7 +84,6 @@
 		359583A128829D93002B6873 /* TestK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestK.swift; sourceTree = "<group>"; };
 		359583A328829D99002B6873 /* TestU.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestU.swift; sourceTree = "<group>"; };
 		359583A72882A6F7002B6873 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
-		359583A928840415002B6873 /* TestJ.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestJ.swift; sourceTree = "<group>"; };
 		C04B547E2887C6250097EE88 /* MockData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockData.swift; sourceTree = "<group>"; };
 		C0DFFBFC2885DC86009A1563 /* ParentUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentUser.swift; sourceTree = "<group>"; };
 		C0DFFC022885DE32009A1563 /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
@@ -132,7 +132,7 @@
 		35171D1128828E6C0059F297 /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				359583A928840415002B6873 /* TestJ.swift */,
+				04797678288E7855009C0826 /* teacherCalenderData.swift */,
 				C0DFFBFC2885DC86009A1563 /* ParentUser.swift */,
 				C0DFFC022885DE32009A1563 /* Message.swift */,
 				C0DFFC042885DF05009A1563 /* Schedule.swift */,
@@ -497,9 +497,9 @@
 				3558AB3928868D2800539C66 /* Notification.swift in Sources */,
 				35958379288297B9002B6873 /* SendingViewController.swift in Sources */,
 				3595837F2882980C002B6873 /* StartViewController.swift in Sources */,
-				359583AA28840415002B6873 /* TestJ.swift in Sources */,
 				3595839B28829CA1002B6873 /* TestI.swift in Sources */,
 				35958362288291D8002B6873 /* TabBarViewController.swift in Sources */,
+				04797679288E7855009C0826 /* teacherCalenderData.swift in Sources */,
 				35958375288295D9002B6873 /* BaseTableViewCell.swift in Sources */,
 				04610D9328868C5E00CCCB2D /* BaseCollectionViewCell.swift in Sources */,
 				C0DFFC092885E1A0009A1563 /* TeacherUser.swift in Sources */,

--- a/Gajeongtongsin/Gajeongtongsin/Global/Literal/Constants.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Global/Literal/Constants.swift
@@ -43,3 +43,7 @@ enum Role {
     case parent
     case teacher
 }
+
+// ParentsCalenderViewController 상수
+let secondsInDay = 86400
+let weekDays = 5

--- a/Gajeongtongsin/Gajeongtongsin/Global/Literal/Constants.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Global/Literal/Constants.swift
@@ -47,3 +47,13 @@ enum Role {
 // ParentsCalenderViewController 상수
 let secondsInDay = 86400
 let weekDays = 5
+
+
+var todayOfTheWeek: Int{
+    let formatter = DateFormatter()
+    formatter.dateFormat = "e"    //e는 1~7(sun~sat)
+    let day = formatter.string(from:Date())
+    var interval = Int(day)
+    if interval == 1 { interval = 8 }
+    return interval!
+}

--- a/Gajeongtongsin/Gajeongtongsin/Global/Literal/MockData.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Global/Literal/MockData.swift
@@ -51,6 +51,6 @@ var scheduleList3 = [
              scheduleList: [
                 ScheduleInfo(consultingDate: "7월25일", startTime: "14시00분", isReserved: nil),
                 ScheduleInfo(consultingDate: "7월26일", startTime: "15시30분", isReserved: nil),
-                ScheduleInfo(consultingDate: "7월26일", startTime: "16시00분", isReserved: nil)],
+                ScheduleInfo(consultingDate: "7월28일", startTime: "16시00분", isReserved: nil)],
              content: "최히로체육성적문의")
 ]

--- a/Gajeongtongsin/Gajeongtongsin/Models/TestJ.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Models/TestJ.swift
@@ -6,3 +6,10 @@
 //
 
 import Foundation
+import UIKit
+
+struct teacherCalenderData {
+    var parentIds: Int
+    var calenderIndex: [Int]
+    var cellColor: UIColor
+}

--- a/Gajeongtongsin/Gajeongtongsin/Models/teacherCalenderData.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Models/teacherCalenderData.swift
@@ -1,8 +1,8 @@
 //
-//  TestJ.swift
+//  teacherCalenderData.swift
 //  Gajeongtongsin
 //
-//  Created by DaeSeong on 2022/07/17.
+//  Created by Beone on 2022/07/25.
 //
 
 import Foundation

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ParentsCalenderViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ParentsCalenderViewController.swift
@@ -52,13 +52,8 @@ class ParentsCalenderViewController: BaseViewController {
     
     func dateIndexToString(index: Int) -> String {
         let formatter = DateFormatter()
-        
-        formatter.dateFormat = "e"    //e는 1~7(sun~sat)
-        var interval = Int(formatter.string(from:Date()))
-        if interval == 1 { interval = 8 } //오늘이 일요일인 경우에는 다음주로 넘어가지 않도록 보정
-        
         formatter.dateFormat = "MMM-dd-e-EEEE"
-        let daysAfterToday = (7+(index%weekDays+2)-interval!) //오늘부터 신청일까지 더해야 하는 일 수, +2는 dateFormat 보정(월요일이 2), +7은 다음주 캘린더가 표시되도록
+        let daysAfterToday = (7+(index%weekDays+2)-todayOfTheWeek) //+2는 dateFormat 보정(월요일이 2), +7은 다음주 캘린더가 표시되도록
         let consultingDateDate = Date(timeIntervalSinceNow: TimeInterval((secondsInDay * daysAfterToday)))
         
         consultingDateList = formatter.string(from: consultingDateDate).components(separatedBy: "-") //Date -> [String]

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ParentsCalenderViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ParentsCalenderViewController.swift
@@ -42,40 +42,40 @@ class ParentsCalenderViewController: BaseViewController {
         subBtn.addTarget(self, action: #selector(onTapButton), for: .touchUpInside)
     }
     
-    //날자 계산을 위한 상수 (근데 왜 let 선언하면 오류가 뜰까?)
-    var interval: Double {
+    //날자 계산을 위한 오늘의 요일 상수
+    var interval: Int {
         let formatter = DateFormatter()
-        formatter.dateFormat = "MMM-dd-e-EEEE"    //e는 1~7(sun~sat)
-
+        formatter.dateFormat = "e"    //e는 1~7(sun~sat)
+        
         let day = formatter.string(from:Date())
-        let today = day.components(separatedBy: "-")
-        let interval = Double(today[2])
-//        let startDay = Date(timeIntervalSinceNow: (86400 * (9-interval!))) //e: 1~7 이므로 7+2(월요일 보정)-interval = 다음주 월요일
-//        let startDayString = formatter.string(from: startDay).components(separatedBy: "-") //다음주 월요일 date
+        var interval = Int(day)
+        if interval == 1 { interval = 8 }
         return interval!
     }
     
     //신청하기 누르면 리로드 & 신청요일, 시간 mackdata에 추가 / print
     @objc func onTapButton() {
         
-        subIdx = choicedCells.enumerated().compactMap { (idx, element) -> Int? in
+        subIdx = choicedCells.enumerated().compactMap { (idx, element) in
             element ? idx : nil
         }
         
         var subSchedule: [ScheduleInfo] = []
         
         for idx in subIdx {
-            var dateCalculate: Date
+            var consultingDateDate: Date
             var consultingDateList: [String]
-            var consultingDate: String
+            var consultingDate: String //consultingDateDate -> consultingDateList -> consultingDate 순으로 탑다운
             var startTime: String = ""
             
             let formatter = DateFormatter()
             formatter.dateFormat = "MMM-dd-e-EEEE"
-            dateCalculate = Date(timeIntervalSinceNow: (86400 * (Double(9+idx%5)-interval))) //다음주 월요일부터 계산, idx가 곧 e (MMM-DD-e-EEEE)
-            consultingDateList = formatter.string(from: dateCalculate).components(separatedBy: "-") //Date -> [String]
-            consultingDate = consultingDateList[0] + consultingDateList[1] + "일" //[String] -> String
+            let daysAfterToday = (Double(9+idx%5)-Double(interval)) //오늘부터 신청일까지 더해야 하는 일 수
             
+            consultingDateDate = Date(timeIntervalSinceNow: (86400 * daysAfterToday))
+            consultingDateList = formatter.string(from: consultingDateDate).components(separatedBy: "-") //Date -> [String]
+            consultingDate = consultingDateList[0] + consultingDateList[1] + "일" //[String] -> String
+            print(consultingDate)
             switch idx/5 {
             case 0:
                 startTime = "14:00"
@@ -97,13 +97,10 @@ class ParentsCalenderViewController: BaseViewController {
         }
         
         let newSchedule: Schedule = Schedule(
-            reservedDate: "7월22일",
+            reservedDate: "7월22일", 
             scheduleList: subSchedule,
             content: "테스트")
-        
-        parentList[0].schedules.append(newSchedule)
-        
-        print(parentList[0].schedules[1])
+        parentList[0].schedules.append(newSchedule) //TODO : - parentList index를 id 받아서 넣어주어야 함
         choicedCells = Array(repeating: false, count:30)
         calenderView.reloadData()
     }
@@ -144,20 +141,20 @@ extension ParentsCalenderViewController: UICollectionViewDelegate{
     
     //캘린더 클릭 액션
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let cell = collectionView.cellForItem(at: indexPath) as? CalenderViewCell
-        
-        //선택한 슬롯 개수 카운터
-        let truCnt = choicedCells.filter({$0 == true}).count
+             let cell = collectionView.cellForItem(at: indexPath) as? CalenderViewCell
 
-        //갯수 3개로 제한 및 선택 토글  +섹션 나눠서 인덱싱 편하게 하기?
-        if truCnt<3 && !choicedCells[indexPath.item] {
-            choicedCells[indexPath.item].toggle()
-            cell?.backgroundColor = .blue
-        }else if truCnt<=3 && choicedCells[indexPath[1]]{
-            choicedCells[indexPath[1]].toggle()
-            cell?.backgroundColor = .gray
-        }
-    }
+             //선택한 슬롯 개수 카운터
+             let truCnt = choicedCells.filter({$0 == true}).count
+
+             //갯수 3개로 제한 및 선택 토글  +섹션 나눠서 인덱싱 편하게 하기?
+             if truCnt<3 && !choicedCells[indexPath.item] {
+                 choicedCells[indexPath.item].toggle()
+                 cell?.backgroundColor = .blue
+             }else if truCnt<=3 && choicedCells[indexPath[1]]{
+                 choicedCells[indexPath[1]].toggle()
+                 cell?.backgroundColor = .gray
+             }
+         }
 }
 
 extension ParentsCalenderViewController: UICollectionViewDataSource{

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ReservationViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ReservationViewController.swift
@@ -8,7 +8,8 @@
 import UIKit
 
 class ReservationViewController: BaseViewController {
-
+    
+    //MARK: - Properties
     private let textLabel: UILabel = {
         let label = UILabel()
         label.text = "학부모님 상담예약 준비중입니다 😎"
@@ -26,19 +27,20 @@ class ReservationViewController: BaseViewController {
         return button
     }()
     
+    //MARK: - View Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
 
         button.addTarget(self, action: #selector(onTapButton), for: .touchUpInside)
     }
     
-
+    //MARK: - Funcs
     @objc func onTapButton() {
         let vc = ParentsCalenderViewController()
         present(vc, animated: true)
     }
     
-    //MARK: - Funcs
+    
     override func render() {
         view.addSubview(textLabel)
         textLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Consultation/ConsultationViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Consultation/ConsultationViewController.swift
@@ -39,46 +39,7 @@ class ConsultationViewController: BaseViewController {
         return nextWeek
     }
     
-    //선택한 학부모의 신청 요일(날자)를 리스트로 반환해주는 함수
-    func dayIndex(parentUserIds: Int) -> [Int] {
-        displayDates = []
-        displayIndex = []
-        for i in 0...mainTeacher.parentUserIds[parentUserIds].schedules[0].scheduleList.count-1 {
-            displayDates.append(mainTeacher.parentUserIds[parentUserIds].schedules[0].scheduleList[i].consultingDate)
-        }
-        for day in 0...displayDates.count-1 {
-            for nextWeekDay in 0...nextWeek.count-1 {
-                if displayDates[day] == nextWeek[nextWeekDay] {
-                    displayIndex.append(nextWeekDay)
-                }
-            }
-        }
-        return displayIndex
-    }
     
-    func timeIndex(parentUserIds: Int) -> [Int] {
-        startTime = []
-        for i in 0...2{
-            switch mainTeacher.parentUserIds[parentUserIds].schedules[0].scheduleList[i].startTime {
-            case "14시00분":
-                startTime.append(0)
-            case "14시30분":
-                startTime.append(1)
-            case "15시00분":
-                startTime.append(2)
-            case "15시30분":
-                startTime.append(3)
-            case "16시00분":
-                startTime.append(4)
-            case "16시30분":
-                startTime.append(5)
-            default:
-                startTime.append(100)
-            }
-        }
-        return startTime
-    }
-
     // 캘린더뷰
     private let calenderView:  UICollectionView = {
         let layout = UICollectionViewFlowLayout()
@@ -127,6 +88,66 @@ class ConsultationViewController: BaseViewController {
     
     //MARK: - Funcs
     
+    //선택한 학부모의 신청 요일(날자)를 리스트로 반환해주는 함수
+    func dayIndex(parentUserIds: Int) -> [Int] {
+        displayDates = []
+        displayIndex = []
+        for i in 0...mainTeacher.parentUserIds[parentUserIds].schedules[0].scheduleList.count-1 {
+            displayDates.append(mainTeacher.parentUserIds[parentUserIds].schedules[0].scheduleList[i].consultingDate)
+        }
+        for day in 0...displayDates.count-1 {
+            for nextWeekDay in 0...nextWeek.count-1 {
+                if displayDates[day] == nextWeek[nextWeekDay] {
+                    displayIndex.append(nextWeekDay)
+                }
+            }
+        }
+        return displayIndex
+    }
+    
+    func timeIndex(parentUserIds: Int) -> [Int] {
+        startTime = []
+        for i in 0...2{
+            switch mainTeacher.parentUserIds[parentUserIds].schedules[0].scheduleList[i].startTime {
+            case "14시00분":
+                startTime.append(0)
+            case "14시30분":
+                startTime.append(1)
+            case "15시00분":
+                startTime.append(2)
+            case "15시30분":
+                startTime.append(3)
+            case "16시00분":
+                startTime.append(4)
+            case "16시30분":
+                startTime.append(5)
+            default:
+                startTime.append(100)
+            }
+        }
+        return startTime
+    }
+    
+    //mockdata의 상담예약 관련 데이터를 teacherCalenderDate에 불러오는 함수
+    func CalenderDisplayData() -> [teacherCalenderData] {
+        
+        calenderData = []
+        calenderData.append(teacherCalenderData(parentIds: 0, calenderIndex: [], cellColor: .green))
+        calenderData.append(teacherCalenderData(parentIds: 1, calenderIndex: [], cellColor: .blue))
+        calenderData.append(teacherCalenderData(parentIds: 2, calenderIndex: [], cellColor: .red))
+
+        for parentIdx in 0...mainTeacher.parentUserIds.count-1 {
+            calenderIndex = []
+            for i in 0...2{
+                calenderIndex.append(timeIndex(parentUserIds: parentIdx)[i] * 5 + dayIndex(parentUserIds: parentIdx)[i])
+            }
+
+            calenderData[parentIdx].calenderIndex = calenderIndex
+        }
+        print(calenderData)
+        return calenderData
+    }
+    
     //버튼 누르면 학부모1 신청시간 display
     @objc func par1OnTapButton() {
         displayData = []
@@ -146,26 +167,6 @@ class ConsultationViewController: BaseViewController {
         displayData = CalenderDisplayData()
         calenderView.reloadData()
     }
-    
-    func CalenderDisplayData() -> [teacherCalenderData] {
-        
-        calenderData = []
-        calenderData.append(teacherCalenderData(parentIds: 0, calenderIndex: [], cellColor: .green))
-        calenderData.append(teacherCalenderData(parentIds: 1, calenderIndex: [], cellColor: .blue))
-        calenderData.append(teacherCalenderData(parentIds: 2, calenderIndex: [], cellColor: .red))
-
-        for parentIdx in 0...mainTeacher.parentUserIds.count-1 {
-            calenderIndex = []
-            for i in 0...2{
-                calenderIndex.append(timeIndex(parentUserIds: parentIdx)[i] * 5 + dayIndex(parentUserIds: parentIdx)[i])
-            }
-
-            calenderData[parentIdx].calenderIndex = calenderIndex
-        }
-        print(calenderData)
-        return calenderData
-    }
-
     
     override func render() {
         view.addSubview(calenderView)

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Consultation/ConsultationViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Consultation/ConsultationViewController.swift
@@ -32,10 +32,12 @@ class ConsultationViewController: BaseViewController {
         var nextWeek = [String]()
         let weekDay: Int = 6
         for dayCount in 0...weekDay {
-            let dayAdded = (86400 * (9-interval!+dayCount))
+//            let dayAdded = (86400 * (9-interval!+dayCount))
+            let dayAdded = (86400 * (2-interval!+dayCount))
             let oneDayString = formatter.string(from: Date(timeIntervalSinceNow: TimeInterval(dayAdded))).components(separatedBy: "-")
             nextWeek.append(oneDayString[0]+oneDayString[1]+"일")
         }
+        print(nextWeek)
         return nextWeek
     }
     

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Consultation/ConsultationViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Consultation/ConsultationViewController.swift
@@ -11,33 +11,22 @@ class ConsultationViewController: BaseViewController {
       
     
     //MARK: - Properties
-    private var choicedCells: [Bool] = Array(repeating: false, count:30) //복수선택 및 선택취소를 위한 array
-    private var displayDates: [String] = [] //displayIndex 입력 전 다음주 날자와 비교를 위한 리스트
-    private var displayIndex: [Int] = [] //신청버튼 클릭 후 신청내역 날자 인덱스가 저장되는 리스트 (인덱스는 캘린더뷰 기준)
-    private var startTime: [Int] = [] //신청버튼 클릭 후 신청내역 시간 인덱스가 저장되는 리스트 ('')
-    private var calenderIndex: [Int] = [] //위 두 변수로 캘린더 인덱스 계산한 리스트
-    private var calenderData: [teacherCalenderData] = [teacherCalenderData(parentIds: 0, calenderIndex: [], cellColor: .gray)]
+    private var choicedCells: [Bool] = Array(repeating: false, count:30)
     private var displayData: [teacherCalenderData] = []
     private var cellColor: UIColor = .gray
     
     //다음 일주일의 날짜 리스트를 반환해주는 함수, 아래의 dayIndex 함수에 사용함
     var nextWeek: [String] {
         let formatter = DateFormatter()
-        formatter.dateFormat = "e"    //e는 1~7(sun~sat)
-        let day = formatter.string(from:Date())
-        var interval = Int(day)
-        if interval == 1 { interval = 8 }
-        
-        formatter.dateFormat = "MMM-dd-e-EEEE"
+        formatter.dateFormat = "MMM-dd"
         var nextWeek = [String]()
-        let weekDay: Int = 6
-        for dayCount in 0...weekDay {
-//            let dayAdded = (86400 * (9-interval!+dayCount))
-            let dayAdded = (86400 * (2-interval!+dayCount))
+        
+        for dayCount in 0..<weekDays+2 { //주말 이틀 추가(weekDays==5)
+//            let dayAdded = (86400 * (2+dayCount-todayOfTheWeek +7)) //캘린더뷰가 다음주를 표시하는 경우 +7
+            let dayAdded = (86400 * (2+dayCount-todayOfTheWeek))
             let oneDayString = formatter.string(from: Date(timeIntervalSinceNow: TimeInterval(dayAdded))).components(separatedBy: "-")
             nextWeek.append(oneDayString[0]+oneDayString[1]+"일")
         }
-        print(nextWeek)
         return nextWeek
     }
     
@@ -91,24 +80,24 @@ class ConsultationViewController: BaseViewController {
     //MARK: - Funcs
     
     //선택한 학부모의 신청 요일(날자)를 리스트로 반환해주는 함수
-    func dayIndex(parentUserIds: Int) -> [Int] {
-        displayDates = []
-        displayIndex = []
-        for i in 0...mainTeacher.parentUserIds[parentUserIds].schedules[0].scheduleList.count-1 {
-            displayDates.append(mainTeacher.parentUserIds[parentUserIds].schedules[0].scheduleList[i].consultingDate)
+    func dateStringToIndex(parentUserIds: Int) -> [Int] {
+        var dateString: [String] = []
+        var dateIndex: [Int] = []
+        for i in 0..<mainTeacher.parentUserIds[parentUserIds].schedules[0].scheduleList.count {
+            dateString.append(mainTeacher.parentUserIds[parentUserIds].schedules[0].scheduleList[i].consultingDate)
         }
-        for day in 0...displayDates.count-1 {
-            for nextWeekDay in 0...nextWeek.count-1 {
-                if displayDates[day] == nextWeek[nextWeekDay] {
-                    displayIndex.append(nextWeekDay)
+        for day in 0..<dateString.count {
+            for nextWeekDay in 0..<nextWeek.count {
+                if dateString[day] == nextWeek[nextWeekDay] {
+                    dateIndex.append(nextWeekDay)
                 }
             }
         }
-        return displayIndex
+        return dateIndex
     }
     
-    func timeIndex(parentUserIds: Int) -> [Int] {
-        startTime = []
+    func timeStringToIndex(parentUserIds: Int) -> [Int] {
+        var startTime:[Int] = []
         for i in 0...2{
             switch mainTeacher.parentUserIds[parentUserIds].schedules[0].scheduleList[i].startTime {
             case "14시00분":
@@ -132,16 +121,16 @@ class ConsultationViewController: BaseViewController {
     
     //mockdata의 상담예약 관련 데이터를 teacherCalenderDate에 불러오는 함수
     func CalenderDisplayData() -> [teacherCalenderData] {
-        
-        calenderData = []
+        var calenderIndex: [Int] = []
+        var calenderData: [teacherCalenderData] = []
         calenderData.append(teacherCalenderData(parentIds: 0, calenderIndex: [], cellColor: .green))
         calenderData.append(teacherCalenderData(parentIds: 1, calenderIndex: [], cellColor: .blue))
         calenderData.append(teacherCalenderData(parentIds: 2, calenderIndex: [], cellColor: .red))
 
-        for parentIdx in 0...mainTeacher.parentUserIds.count-1 {
+        for parentIdx in 0..<mainTeacher.parentUserIds.count {
             calenderIndex = []
             for i in 0...2{
-                calenderIndex.append(timeIndex(parentUserIds: parentIdx)[i] * 5 + dayIndex(parentUserIds: parentIdx)[i])
+                calenderIndex.append(timeStringToIndex(parentUserIds: parentIdx)[i] * weekDays + dateStringToIndex(parentUserIds: parentIdx)[i])
             }
 
             calenderData[parentIdx].calenderIndex = calenderIndex
@@ -219,10 +208,10 @@ extension ConsultationViewController: UICollectionViewDelegate{
     }
     
     //cell 클릭 액션
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let cell = collectionView.cellForItem(at: indexPath) as? CalenderViewCell
-        
-    }
+//    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+//        let cell = collectionView.cellForItem(at: indexPath) as? CalenderViewCell
+//
+//    }
 }
 
 extension ConsultationViewController: UICollectionViewDataSource {


### PR DESCRIPTION
## 🍏 관련 이슈
<!-- 해당 PR과 관련된 이슈를 링크해주세요. -->
#24

## 🍏 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
학부모의 캘린더뷰 feature을 그대로 사용했고, cell 파일은 공유합니다
데이터->뷰 로직을 함수로 만들어서 가독성이 떨어질 수 있겠습니다
스크린샷에서 왼쪽의 학부모1을 선택하면 목데이터의 학부모리스트[0] 의 예약시간이 나오고, 학부모 2도 마찬가지입니다
전체보기는 아직 구현하지 못했습니다

<img width="1018" alt="스크린샷 2022-07-23 14 10 57" src="https://user-images.githubusercontent.com/70618615/180591746-93b4f722-53fb-47d4-8c79-a2989cba990c.png">


## 🍏 다음으로 진행될 작업
 - [ ] 전체보기 구현
 - [ ] 코드 리펙터링

## 🍏 주의사항
- **빈 폴더 있는지 확인하기!!**
- **파일,폴더 위치 및 이동 하지말기!!**
