### PR TITLE
[ADD] 학부모 전화상담 뷰 (일반상담예약 뷰, 기능 미구현)

### DIFF
--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ParentsCalenderViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ParentsCalenderViewController.swift
@@ -114,8 +114,7 @@ class ParentsCalenderViewController: BaseViewController {
         subIdx = choicedCells.enumerated().compactMap { (idx, element) -> Int? in
             element ? idx : nil
         }
-        
-        print(subIdx)
+
         choicedCells = Array(repeating: false, count:30)
         calenderView.reloadData()
     }

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ParentsCalenderViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ParentsCalenderViewController.swift
@@ -54,21 +54,17 @@ class ParentsCalenderViewController: BaseViewController {
         note.text = "어떤 내용으로 상담을 신청하시나요?"
         note.font = .systemFont(ofSize: 15)
         note.clearsOnInsertion = false
-        note.translatesAutoresizingMaskIntoConstraints = false
         note.layer.borderWidth = 0.5
+        note.translatesAutoresizingMaskIntoConstraints = false
         return note
     }()
     
+    //MARK: - View Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
         calenderView.delegate = self
         calenderView.dataSource = self
-        
-//        self.navigationController?.popViewController(animated: true)
-//        self.navigationController?.isNavigationBarHidden = false
-//        self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: dismiss)
-//        self.navigationItem.backBarButtonItem = UIBarButtonItem(systemItem: UIBarButtonItem.SystemItem.cancel)
-//        self.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: submit)
+
         
         submitBtn.addTarget(self, action: #selector(onTapButton), for: .touchUpInside)
         dismissBtn.addTarget(self, action: #selector(cancelSubmit), for: .touchUpInside)
@@ -78,15 +74,13 @@ class ParentsCalenderViewController: BaseViewController {
     
     override func render() {
         view.addSubview(dismissBtn)
-        dismissBtn.topAnchor.constraint(equalTo: view.topAnchor, constant: 50).isActive = true
+        dismissBtn.topAnchor.constraint(equalTo: view.topAnchor, constant: 20).isActive = true
         dismissBtn.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 30).isActive = true
 
-
         view.addSubview(submitBtn)
-        submitBtn.topAnchor.constraint(equalTo: view.topAnchor, constant: 50).isActive = true
+        submitBtn.topAnchor.constraint(equalTo: view.topAnchor, constant: 20).isActive = true
         submitBtn.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -30).isActive = true
 
-        
         view.addSubview(calenderView)
         calenderView.topAnchor.constraint(equalTo: view.topAnchor, constant: 100).isActive = true
         calenderView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
@@ -104,9 +98,6 @@ class ParentsCalenderViewController: BaseViewController {
         reasonNote.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 30).isActive = true
         reasonNote.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -30).isActive = true
         reasonNote.heightAnchor.constraint(equalToConstant: 100).isActive = true
-        
-
-
     }
 
     override func configUI() {

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ParentsCalenderViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ParentsCalenderViewController.swift
@@ -22,27 +22,104 @@ class ParentsCalenderViewController: BaseViewController {
         return collectionView
     }()
     
-    // 신청버튼
-    private let subBtn: UIButton = {
+    // 신청/취소 버튼
+    private let dismissBtn: UIButton = {
         let button = UIButton()
-        button.setTitle("신청하기", for: .normal)
-        button.setTitleColor(.black, for: .normal)
+        button.setTitle("취소", for: .normal)
+        button.setTitleColor(UIColor.systemBlue, for: .normal)
         button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()
     
+    private let submitBtn: UIButton = {
+        let button = UIButton()
+        button.setTitle("신청", for: .normal)
+        button.setTitleColor(UIColor.systemBlue, for: .normal)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+    
+    private let noteTitle: UILabel = {
+        let label = UILabel()
+        label.text = "상담용건"
+        label.font = UIFont.systemFont(ofSize: 20, weight: .medium)
+        label.textColor = .black
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    //사유 입력 text view
+    private let reasonNote: UITextView = {
+        let note = UITextView()
+        note.text = "어떤 내용으로 상담을 신청하시나요?"
+        note.font = .systemFont(ofSize: 15)
+        note.clearsOnInsertion = false
+        note.translatesAutoresizingMaskIntoConstraints = false
+        note.layer.borderWidth = 0.5
+        return note
+    }()
     
     override func viewDidLoad() {
         super.viewDidLoad()
         calenderView.delegate = self
         calenderView.dataSource = self
         
-        subBtn.addTarget(self, action: #selector(onTapButton), for: .touchUpInside)
+//        self.navigationController?.popViewController(animated: true)
+//        self.navigationController?.isNavigationBarHidden = false
+//        self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: dismiss)
+//        self.navigationItem.backBarButtonItem = UIBarButtonItem(systemItem: UIBarButtonItem.SystemItem.cancel)
+//        self.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: submit)
+        
+        submitBtn.addTarget(self, action: #selector(onTapButton), for: .touchUpInside)
+        dismissBtn.addTarget(self, action: #selector(dm), for: .touchUpInside)
+    }
+
+    //MARK: - Funcs
+    
+    override func render() {
+        view.addSubview(dismissBtn)
+        dismissBtn.topAnchor.constraint(equalTo: view.topAnchor, constant: 50).isActive = true
+        dismissBtn.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 30).isActive = true
+
+
+        view.addSubview(submitBtn)
+        submitBtn.topAnchor.constraint(equalTo: view.topAnchor, constant: 50).isActive = true
+        submitBtn.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -30).isActive = true
+
+        
+        view.addSubview(calenderView)
+        calenderView.topAnchor.constraint(equalTo: view.topAnchor, constant: 100).isActive = true
+        calenderView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+        calenderView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 50).isActive = true
+        calenderView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -50).isActive = true
+        
+        view.addSubview(noteTitle)
+        noteTitle.topAnchor.constraint(equalTo: calenderView.topAnchor, constant: 330).isActive = true
+        noteTitle.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 30).isActive = true
+        noteTitle.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -30).isActive = true
+        noteTitle.heightAnchor.constraint(equalToConstant: 20).isActive = true
+        
+        view.addSubview(reasonNote)
+        reasonNote.topAnchor.constraint(equalTo: noteTitle.topAnchor, constant: 35).isActive = true
+        reasonNote.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 30).isActive = true
+        reasonNote.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -30).isActive = true
+        reasonNote.heightAnchor.constraint(equalToConstant: 100).isActive = true
+        
+
+
+    }
+
+    override func configUI() {
+        view.backgroundColor = .white
+    }
+    
+    //캘린더뷰 신청 취소
+    @objc func dm() {
+        self.dismiss(animated: true)
     }
     
     //신청하기 누르면 리로드 & 신청시간 인덱스 subIdx에 저장 / print
     @objc func onTapButton() {
-        
         subIdx = choicedCells.enumerated().compactMap { (idx, element) -> Int? in
             element ? idx : nil
         }
@@ -50,24 +127,6 @@ class ParentsCalenderViewController: BaseViewController {
         print(subIdx)
         choicedCells = Array(repeating: false, count:30)
         calenderView.reloadData()
-    }
-
-    //MARK: - Funcs
-    
-    override func render() {
-        view.addSubview(calenderView)
-        calenderView.topAnchor.constraint(equalTo: view.topAnchor, constant: 200).isActive = true
-        calenderView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
-        calenderView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 50).isActive = true
-        calenderView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -50).isActive = true
-        
-        view.addSubview(subBtn)
-        subBtn.topAnchor.constraint(equalTo: calenderView.topAnchor, constant: 300).isActive = true
-        subBtn.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 50).isActive = true
-    }
-
-    override func configUI() {
-        view.backgroundColor = .white
     }
 }
 

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ParentsCalenderViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ParentsCalenderViewController.swift
@@ -71,7 +71,7 @@ class ParentsCalenderViewController: BaseViewController {
 //        self.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: submit)
         
         submitBtn.addTarget(self, action: #selector(onTapButton), for: .touchUpInside)
-        dismissBtn.addTarget(self, action: #selector(dm), for: .touchUpInside)
+        dismissBtn.addTarget(self, action: #selector(cancelSubmit), for: .touchUpInside)
     }
 
     //MARK: - Funcs
@@ -114,7 +114,7 @@ class ParentsCalenderViewController: BaseViewController {
     }
     
     //캘린더뷰 신청 취소
-    @objc func dm() {
+    @objc func cancelSubmit() {
         self.dismiss(animated: true)
     }
     

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ReservationViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ReservationViewController.swift
@@ -67,10 +67,20 @@ class ReservationViewController: BaseViewController {
                 print("상담예약")
             }),
             UIAction(title: "긴급신청", handler: { _ in
+                let alert = UIAlertController(title: "긴급 상담 요청", message: "정말 급한 상담인지 다시 한 번 생각해주세요", preferredStyle: .alert)
+                let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+                let okayAction = UIAlertAction(title: "신청", style: .default) { _ in
+                    let text: String = alert.textFields?[0].text ?? ""
+//                    print(text)
+                }
+                alert.addAction(cancelAction)
+                alert.addAction(okayAction)
+                alert.addTextField()
+                self.present(alert, animated: true)
+                
 
-                print("긴급신청")
             })
         ])
     }
-    
 }
+

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ReservationViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ReservationViewController.swift
@@ -14,7 +14,7 @@ class ReservationViewController: BaseViewController {
     private let viewTitle: UILabel = {
         let label = UILabel()
         label.text = "예약내역"
-        label.font = UIFont.systemFont(ofSize: 28)
+        label.font = UIFont.systemFont(ofSize: 28, weight: .bold)
         label.textColor = .black
         label.translatesAutoresizingMaskIntoConstraints = false
         return label

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ReservationViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ReservationViewController.swift
@@ -38,10 +38,9 @@ class ReservationViewController: BaseViewController {
         return button
     }()
     
+    //MARK: - View Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: reserveButton)
-        self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: viewTitle)
     }
 
     
@@ -58,6 +57,8 @@ class ReservationViewController: BaseViewController {
 
     override func configUI() {
         view.backgroundColor = .primaryBackground
+        self.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: reserveButton)
+        self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: viewTitle)
         
         //신청버튼 메뉴에 따라 액션 분리
         reserveButton.menu = UIMenu(options: .displayInline, children: [
@@ -68,13 +69,12 @@ class ReservationViewController: BaseViewController {
                 let alert = UIAlertController(title: "긴급 상담 요청", message: "정말 급한 상담인지 다시 한 번 생각해주세요", preferredStyle: .alert)
                 let cancelAction = UIAlertAction(title: "취소", style: .cancel)
                 let okayAction = UIAlertAction(title: "신청", style: .default) { _ in
-                    let text: String = alert.textFields?[0].text ?? ""
-//                    print(text)
+                    let _: String = alert.textFields?[0].text ?? ""
                 }
                 alert.addAction(cancelAction)
                 alert.addAction(okayAction)
                 alert.addTextField()
-                alert.textFields?[0].placeholder = "상담 요건 작성"
+                alert.textFields?[0].placeholder = "상담 용건 작성"
                 self.present(alert, animated: true)
                 
 

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ReservationViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ReservationViewController.swift
@@ -29,7 +29,7 @@ class ReservationViewController: BaseViewController {
         return label
     }()
     
-    private let button: UIButton = {
+    private let reserveButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(systemName: "calendar.badge.plus"), for: .normal)
         button.setTitleColor(.black, for: .normal)
@@ -37,11 +37,10 @@ class ReservationViewController: BaseViewController {
         button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()
-
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: button)
+        self.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: reserveButton)
         self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: viewTitle)
     }
 
@@ -52,19 +51,18 @@ class ReservationViewController: BaseViewController {
         textLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
         textLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
         
-        view.addSubview(button)
-        button.topAnchor.constraint(equalTo: view.topAnchor, constant: 100).isActive = true
-        button.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 180).isActive = true
+        view.addSubview(reserveButton)
+        reserveButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 100).isActive = true
+        reserveButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 180).isActive = true
     }
 
     override func configUI() {
         view.backgroundColor = .primaryBackground
         
         //신청버튼 메뉴에 따라 액션 분리
-        button.menu = UIMenu(options: .displayInline, children: [
+        reserveButton.menu = UIMenu(options: .displayInline, children: [
             UIAction(title: "상담예약", handler: { _ in
                 self.present(ParentsCalenderViewController(), animated: true)
-                print("상담예약")
             }),
             UIAction(title: "긴급신청", handler: { _ in
                 let alert = UIAlertController(title: "긴급 상담 요청", message: "정말 급한 상담인지 다시 한 번 생각해주세요", preferredStyle: .alert)
@@ -76,6 +74,7 @@ class ReservationViewController: BaseViewController {
                 alert.addAction(cancelAction)
                 alert.addAction(okayAction)
                 alert.addTextField()
+                alert.textFields?[0].placeholder = "상담 요건 작성"
                 self.present(alert, animated: true)
                 
 

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ReservationViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ReservationViewController.swift
@@ -8,10 +8,21 @@
 import UIKit
 
 class ReservationViewController: BaseViewController {
+    //TODO: -
+    /// 신청내역 리스트 테이블뷰
 
+    private let viewTitle: UILabel = {
+        let label = UILabel()
+        label.text = "예약내역"
+        label.font = UIFont.systemFont(ofSize: 28)
+        label.textColor = .black
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
     private let textLabel: UILabel = {
         let label = UILabel()
-        label.text = "학부모님 상담예약 준비중입니다 😎"
+        label.text = "예정된 상담이 없어요 :)"
         label.font = UIFont.systemFont(ofSize: 20)
         label.textColor = .black
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -20,23 +31,20 @@ class ReservationViewController: BaseViewController {
     
     private let button: UIButton = {
         let button = UIButton()
-        button.setTitle("상담예약 캘린더뷰 버튼", for: .normal)
+        button.setImage(UIImage(systemName: "calendar.badge.plus"), for: .normal)
         button.setTitleColor(.black, for: .normal)
+        button.showsMenuAsPrimaryAction = true
         button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()
+
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        button.addTarget(self, action: #selector(onTapButton), for: .touchUpInside)
+        self.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: button)
+        self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: viewTitle)
     }
-    
 
-    @objc func onTapButton() {
-        let vc = ParentsCalenderViewController()
-        present(vc, animated: true)
-    }
     
     //MARK: - Funcs
     override func render() {
@@ -51,5 +59,18 @@ class ReservationViewController: BaseViewController {
 
     override func configUI() {
         view.backgroundColor = .primaryBackground
+        
+        //신청버튼 메뉴에 따라 액션 분리
+        button.menu = UIMenu(options: .displayInline, children: [
+            UIAction(title: "상담예약", handler: { _ in
+                self.present(ParentsCalenderViewController(), animated: true)
+                print("상담예약")
+            }),
+            UIAction(title: "긴급신청", handler: { _ in
+
+                print("긴급신청")
+            })
+        ])
     }
+    
 }


### PR DESCRIPTION
## 🍏 관련 이슈
#22 

## 🍏 작업내용
<img width="358" alt="image" src="https://user-images.githubusercontent.com/103012800/180592162-274c602b-1c46-4695-96bd-e19a4650d044.png">

<img width="349" alt="image" src="https://user-images.githubusercontent.com/103012800/180592167-64500516-55f7-4c71-b5d7-46aa66858417.png">

<img width="352" alt="image" src="https://user-images.githubusercontent.com/103012800/180592178-0c562fb7-609d-44bc-abee-85606049f6cf.png">

- 전화예약 클릭 시 기본 뷰 및 버튼 구현
- 버튼 메뉴 구현
- 상담예약 클릭 시 캘린더뷰 모달 팝업 구현

## 🍏 다음으로 진행될 작업
 - [ ] 사유입력 텍스트뷰 상세 설정 (내용 입력 시 기본 노출 문구 자동 삭제, 폰트 사이즈, 여백 등)
 - [ ] 신청 버튼 클릭 시 캘린더 슬롯 정보와 함께 사유도 같이 목데이터로 전송
 - [x] 긴급신청 Alert 입력 뷰

## 🍏 주의사항
- **빈 폴더 있는지 확인하기!!**
- **파일,폴더 위치 및 이동 하지말기!!**
