### PR TITLE
[ADD] 교사 캘린더뷰 예약확정 기능 및 확정 팬딩 구현

### DIFF
--- a/Gajeongtongsin/Gajeongtongsin/Global/Literal/MockData.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Global/Literal/MockData.swift
@@ -34,26 +34,26 @@ var messageList3 = [
 var scheduleList1 = [
     Schedule(reservedDate: "8월1일",
              scheduleList: [
-                ScheduleInfo(consultingDate: "7월27일", startTime: "14시00분", isReserved: nil),
-                ScheduleInfo(consultingDate: "7월27일", startTime: "14시30분", isReserved: nil),
-                ScheduleInfo(consultingDate: "7월27일", startTime: "15시00분", isReserved: nil)],
+                ScheduleInfo(consultingDate: "7월27일", startTime: "14시00분", isReserved: false),
+                ScheduleInfo(consultingDate: "7월27일", startTime: "14시30분", isReserved: false),
+                ScheduleInfo(consultingDate: "7월27일", startTime: "15시00분", isReserved: false)],
              content: "김유쓰영어성적문의")
 ]
 
 var scheduleList2 = [
     Schedule(reservedDate: "8월2일",
              scheduleList: [
-                ScheduleInfo(consultingDate: "7월27일", startTime: "15시30분", isReserved: nil),
-                ScheduleInfo(consultingDate: "7월26일", startTime: "16시00분", isReserved: nil),
-                ScheduleInfo(consultingDate: "7월25일", startTime: "16시30분", isReserved: nil)],
+                ScheduleInfo(consultingDate: "7월27일", startTime: "15시30분", isReserved: false),
+                ScheduleInfo(consultingDate: "7월26일", startTime: "16시00분", isReserved: false),
+                ScheduleInfo(consultingDate: "7월25일", startTime: "16시30분", isReserved: false)],
              content: "부니카수학성적문의")
 ]
 
 var scheduleList3 = [
     Schedule(reservedDate: "8월3일",
              scheduleList: [
-                ScheduleInfo(consultingDate: "7월25일", startTime: "14시00분", isReserved: nil),
-                ScheduleInfo(consultingDate: "7월26일", startTime: "15시30분", isReserved: nil),
-                ScheduleInfo(consultingDate: "7월28일", startTime: "16시00분", isReserved: nil)],
+                ScheduleInfo(consultingDate: "7월25일", startTime: "14시00분", isReserved: false),
+                ScheduleInfo(consultingDate: "7월26일", startTime: "15시30분", isReserved: false),
+                ScheduleInfo(consultingDate: "7월28일", startTime: "16시00분", isReserved: false)],
              content: "최히로체육성적문의")
 ]

--- a/Gajeongtongsin/Gajeongtongsin/Models/Schedule.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Models/Schedule.swift
@@ -8,6 +8,6 @@
 import Foundation
 struct Schedule {
     let reservedDate: String            //상담신청날짜
-    let scheduleList: [ScheduleInfo]  //스케줄정보들
+    var scheduleList: [ScheduleInfo]  //스케줄정보들
     let content: String               //상담내용
 }

--- a/Gajeongtongsin/Gajeongtongsin/Models/ScheduleInfo.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Models/ScheduleInfo.swift
@@ -9,5 +9,5 @@ import Foundation
 struct ScheduleInfo {
     let consultingDate: String         //상담원하는날짜
     let startTime: String              //상담시작시간(단위시간이 정해져있어서 끝나는시간은 안넣음)
-    let isReserved: Bool?              //nil = 대기, false = 예약불가, true = 완료
+    var isReserved: Bool             //nil = 대기, false = 예약불가, true = 완료
 }

--- a/Gajeongtongsin/Gajeongtongsin/Models/teacherCalenderData.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Models/teacherCalenderData.swift
@@ -10,6 +10,12 @@ import UIKit
 
 struct teacherCalenderData {
     var parentIds: Int
+//    var calenderIndex: calenderIndex
     var calenderIndex: [Int]
     var cellColor: UIColor
 }
+
+//struct calenderIndex {
+//    var displayIndex: [Int]
+//    var isReserved: Bool?
+//}

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ParentsCalenderViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ParentsCalenderViewController.swift
@@ -92,22 +92,11 @@ class ParentsCalenderViewController: BaseViewController {
     }
     
     func timeIndexToString(index: Int) -> String {
-        switch index/numberOfRow {
-        case 0:
-            startTime = "14:00"
-        case 1:
-            startTime = "14:30"
-        case 2:
-            startTime = "15:00"
-        case 3:
-            startTime = "15:30"
-        case 4:
-            startTime = "16:00"
-        case 5:
-            startTime = "16:30"
-        default:
-            startTime = "부니카"
-        }
+        
+        let hour = String(14 + (index/numberOfRow)/2) //14시 + @
+        let minute: String = (index/numberOfRow) % 2 == 0 ? "00" : "30" //짝수줄은 정각, 홀수줄은 30분
+        startTime = hour+"시"+minute+"분"
+        
         return startTime
     }
     
@@ -121,7 +110,7 @@ class ParentsCalenderViewController: BaseViewController {
             appendScheduleList.append(ScheduleInfo(
                 consultingDate: dateIndexToString(index: idx),
                 startTime: timeIndexToString(index: idx),
-                isReserved: nil))
+                isReserved: false))
         }
         
         parentList[0].schedules.append(Schedule(


### PR DESCRIPTION
## 🍏 관련 이슈
<!-- 해당 PR과 관련된 이슈를 링크해주세요. -->
#33 

## 🍏 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
확정과정 : 학부모 버튼 클릭-> 슬롯 터치-> 검은색(예약확정 대체) 터치 -> 확정(흰색 슬롯으로 나타남)

예약확정 버튼 UI가 정해지지 않았기에 그냥 검은색 버튼으로 대체했습니다
신청 슬롯 중 하나를 탭했다가 취소하고 싶으면 신청 슬롯 외 공간을 터치하면 확정하기 버튼(검은버튼)이 사라집니다
예약을 확정한 뒤에는 다른 액션을 취해도 흰색 슬롯이 항상 남아있습니다
데이터는 schedulList 중 확정된 예약 외에는 삭제되고 확정된 건의 isReserved 는 true가 되어 메인화면에 표시될 수 있게 했습니다

<img width="160" alt="스크린샷 2022-07-26 16 54 29" src="https://user-images.githubusercontent.com/70618615/180955271-e5ba53c8-645c-4283-9c98-7fc13d3a22e1.png"> <img width="160" alt="스크린샷 2022-07-26 16 54 37" src="https://user-images.githubusercontent.com/70618615/180953809-0788325a-4b0a-4fc0-b1e8-cd30553a9694.png"> <img width="160" alt="스크린샷 2022-07-26 16 54 43" src="https://user-images.githubusercontent.com/70618615/180953826-2cc08c9e-afc3-42d3-9594-9d7e75159644.png"> <img width="160" alt="스크린샷 2022-07-26 16 54 51" src="https://user-images.githubusercontent.com/70618615/180953841-4808bd0d-12c0-4032-b80d-fc387f724a6a.png">


## 🍏 다음으로 진행될 작업
 - [ ] 학부모 캘린더뷰 팬딩

## 🍏 주의사항
- **빈 폴더 있는지 확인하기!!**
- **파일,폴더 위치 및 이동 하지말기!!**
