### PR TITLE
[ADD] 교사 캘린더뷰 - 학부모 목록 버튼에서 테이블뷰로 변경

### DIFF
--- a/Gajeongtongsin/Gajeongtongsin.xcodeproj/project.pbxproj
+++ b/Gajeongtongsin/Gajeongtongsin.xcodeproj/project.pbxproj
@@ -10,7 +10,7 @@
 		045D0DBE2888DDB700778EEC /* ParentsCalenderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 045D0DBD2888DDB700778EEC /* ParentsCalenderViewController.swift */; };
 		04610D9328868C5E00CCCB2D /* BaseCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04610D9228868C5E00CCCB2D /* BaseCollectionViewCell.swift */; };
 		04610D952886A28C00CCCB2D /* CalenderViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04610D942886A28C00CCCB2D /* CalenderViewCell.swift */; };
-		04797679288E7855009C0826 /* teacherCalenderData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04797678288E7855009C0826 /* teacherCalenderData.swift */; };
+		04797679288E7855009C0826 /* TeacherCalenderData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04797678288E7855009C0826 /* TeacherCalenderData.swift */; };
 		35171CFE28828C930059F297 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35171CFD28828C930059F297 /* AppDelegate.swift */; };
 		35171D0028828C930059F297 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35171CFF28828C930059F297 /* SceneDelegate.swift */; };
 		35171D0728828C930059F297 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 35171D0628828C930059F297 /* Assets.xcassets */; };
@@ -58,7 +58,7 @@
 		045D0DBD2888DDB700778EEC /* ParentsCalenderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentsCalenderViewController.swift; sourceTree = "<group>"; };
 		04610D9228868C5E00CCCB2D /* BaseCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCollectionViewCell.swift; sourceTree = "<group>"; };
 		04610D942886A28C00CCCB2D /* CalenderViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalenderViewCell.swift; sourceTree = "<group>"; };
-		04797678288E7855009C0826 /* teacherCalenderData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = teacherCalenderData.swift; sourceTree = "<group>"; };
+		04797678288E7855009C0826 /* TeacherCalenderData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeacherCalenderData.swift; sourceTree = "<group>"; };
 		35171CFA28828C930059F297 /* Gajeongtongsin.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Gajeongtongsin.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		35171CFD28828C930059F297 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		35171CFF28828C930059F297 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -144,7 +144,7 @@
 		35171D1128828E6C0059F297 /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				04797678288E7855009C0826 /* teacherCalenderData.swift */,
+				04797678288E7855009C0826 /* TeacherCalenderData.swift */,
 				C0DFFBFC2885DC86009A1563 /* ParentUser.swift */,
 				C0DFFC022885DE32009A1563 /* Message.swift */,
 				C0DFFC042885DF05009A1563 /* Schedule.swift */,
@@ -523,7 +523,7 @@
 				C054017F288D0520002BF33B /* NotificationTableViewCell.swift in Sources */,
 				3595839B28829CA1002B6873 /* TestI.swift in Sources */,
 				35958362288291D8002B6873 /* TabBarViewController.swift in Sources */,
-				04797679288E7855009C0826 /* teacherCalenderData.swift in Sources */,
+				04797679288E7855009C0826 /* TeacherCalenderData.swift in Sources */,
 				35958375288295D9002B6873 /* BaseTableViewCell.swift in Sources */,
 				04610D9328868C5E00CCCB2D /* BaseCollectionViewCell.swift in Sources */,
 				C0DFFC092885E1A0009A1563 /* TeacherUser.swift in Sources */,

--- a/Gajeongtongsin/Gajeongtongsin.xcodeproj/project.pbxproj
+++ b/Gajeongtongsin/Gajeongtongsin.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		045D0DBE2888DDB700778EEC /* ParentsCalenderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 045D0DBD2888DDB700778EEC /* ParentsCalenderViewController.swift */; };
 		04610D9328868C5E00CCCB2D /* BaseCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04610D9228868C5E00CCCB2D /* BaseCollectionViewCell.swift */; };
 		04610D952886A28C00CCCB2D /* CalenderViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04610D942886A28C00CCCB2D /* CalenderViewCell.swift */; };
+		046BFDF62890DD8000591577 /* CalenderTabelViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 046BFDF52890DD8000591577 /* CalenderTabelViewCell.swift */; };
 		04797679288E7855009C0826 /* TeacherCalenderData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04797678288E7855009C0826 /* TeacherCalenderData.swift */; };
 		35171CFE28828C930059F297 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35171CFD28828C930059F297 /* AppDelegate.swift */; };
 		35171D0028828C930059F297 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35171CFF28828C930059F297 /* SceneDelegate.swift */; };
@@ -30,7 +31,6 @@
 		3595838928829C1D002B6873 /* Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3595838828829C1D002B6873 /* Test.swift */; };
 		3595838B28829C2C002B6873 /* Test2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3595838A28829C2C002B6873 /* Test2.swift */; };
 		3595838D28829C6C002B6873 /* TestA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3595838C28829C6C002B6873 /* TestA.swift */; };
-		3595838F28829C74002B6873 /* TestB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3595838E28829C74002B6873 /* TestB.swift */; };
 		3595839128829C7B002B6873 /* TestC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3595839028829C7B002B6873 /* TestC.swift */; };
 		3595839328829C82002B6873 /* TestD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3595839228829C82002B6873 /* TestD.swift */; };
 		3595839528829C89002B6873 /* TestF.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3595839428829C89002B6873 /* TestF.swift */; };
@@ -58,6 +58,7 @@
 		045D0DBD2888DDB700778EEC /* ParentsCalenderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentsCalenderViewController.swift; sourceTree = "<group>"; };
 		04610D9228868C5E00CCCB2D /* BaseCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCollectionViewCell.swift; sourceTree = "<group>"; };
 		04610D942886A28C00CCCB2D /* CalenderViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalenderViewCell.swift; sourceTree = "<group>"; };
+		046BFDF52890DD8000591577 /* CalenderTabelViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalenderTabelViewCell.swift; sourceTree = "<group>"; };
 		04797678288E7855009C0826 /* TeacherCalenderData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeacherCalenderData.swift; sourceTree = "<group>"; };
 		35171CFA28828C930059F297 /* Gajeongtongsin.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Gajeongtongsin.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		35171CFD28828C930059F297 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -80,7 +81,6 @@
 		3595838828829C1D002B6873 /* Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test.swift; sourceTree = "<group>"; };
 		3595838A28829C2C002B6873 /* Test2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test2.swift; sourceTree = "<group>"; };
 		3595838C28829C6C002B6873 /* TestA.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestA.swift; sourceTree = "<group>"; };
-		3595838E28829C74002B6873 /* TestB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestB.swift; sourceTree = "<group>"; };
 		3595839028829C7B002B6873 /* TestC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestC.swift; sourceTree = "<group>"; };
 		3595839228829C82002B6873 /* TestD.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestD.swift; sourceTree = "<group>"; };
 		3595839428829C89002B6873 /* TestF.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestF.swift; sourceTree = "<group>"; };
@@ -318,7 +318,7 @@
 		3595836A28829491002B6873 /* Cell */ = {
 			isa = PBXGroup;
 			children = (
-				3595838E28829C74002B6873 /* TestB.swift */,
+				046BFDF52890DD8000591577 /* CalenderTabelViewCell.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -505,6 +505,7 @@
 				3595838928829C1D002B6873 /* Test.swift in Sources */,
 				3595839E28829D80002B6873 /* ProfileViewController.swift in Sources */,
 				C054017D288D04F6002BF33B /* NotificationViewController.swift in Sources */,
+				046BFDF62890DD8000591577 /* CalenderTabelViewCell.swift in Sources */,
 				C056F6AD288B0A770070EED5 /* MessageVIewController.swift in Sources */,
 				35171CFE28828C930059F297 /* AppDelegate.swift in Sources */,
 				359583A228829D93002B6873 /* TestK.swift in Sources */,
@@ -530,7 +531,6 @@
 				35171D0028828C930059F297 /* SceneDelegate.swift in Sources */,
 				C0DFFBFD2885DC86009A1563 /* ParentUser.swift in Sources */,
 				359583A428829D99002B6873 /* TestU.swift in Sources */,
-				3595838F28829C74002B6873 /* TestB.swift in Sources */,
 				3595839128829C7B002B6873 /* TestC.swift in Sources */,
 				045D0DBE2888DDB700778EEC /* ParentsCalenderViewController.swift in Sources */,
 				35958383288299AE002B6873 /* UIColor+Extension.swift in Sources */,

--- a/Gajeongtongsin/Gajeongtongsin/Global/Literal/Constants.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Global/Literal/Constants.swift
@@ -57,3 +57,4 @@ var todayOfTheWeek: Int{
     if interval == 1 { interval = 8 }
     return interval!
 }
+

--- a/Gajeongtongsin/Gajeongtongsin/Models/TeacherCalenderData.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Models/TeacherCalenderData.swift
@@ -8,7 +8,7 @@
 import Foundation
 import UIKit
 
-struct teacherCalenderData {
+struct TeacherCalenderData {
     var parentIds: Int
 //    var calenderIndex: calenderIndex
     var calenderIndex: [Int]

--- a/Gajeongtongsin/Gajeongtongsin/Models/TeacherCalenderData.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Models/TeacherCalenderData.swift
@@ -14,8 +14,3 @@ struct TeacherCalenderData {
     var calenderIndex: [Int]
     var cellColor: UIColor
 }
-
-//struct calenderIndex {
-//    var displayIndex: [Int]
-//    var isReserved: Bool?
-//}

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ParentsCalenderViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ParentsCalenderViewController.swift
@@ -11,7 +11,7 @@ class ParentsCalenderViewController: BaseViewController {
     
     //MARK: - Properties
     private var choicedCells: [Bool] = Array(repeating: false, count:30) //복수선택 및 선택취소를 위한 array
-    private var subIdx: [Int] = [] //신청버튼 클릭 후 신청내역 인덱스가 저장되는 리스트
+    private var submitIndexList: [Int] = [] //신청버튼 클릭 후 신청내역 인덱스가 저장되는 리스트
     private var appendScheduleList: [ScheduleInfo] = []
     private var subDate: [String] = []
 //    private var consultingDateDate: Date
@@ -19,7 +19,6 @@ class ParentsCalenderViewController: BaseViewController {
     private var consultingDate: String = "" //consultingDateDate -> consultingDateList -> consultingDate 순으로 탑다운
     private var startTime: String = ""
 
-    private let numberOfRow = 5
     
     // 캘린더뷰
     private let calenderView:  UICollectionView = {
@@ -92,7 +91,7 @@ class ParentsCalenderViewController: BaseViewController {
     }
     
     func timeIndexToString(index: Int) -> String {
-        let rowInCalender = index/numberOfRow
+        let rowInCalender = index/weekDays
         let hour = String(14 + (rowInCalender)/2) //14시 + @
         let minute: String = (rowInCalender) % 2 == 0 ? "00" : "30" //짝수줄은 정각, 홀수줄은 30분
         startTime = hour+"시"+minute+"분"
@@ -104,12 +103,12 @@ class ParentsCalenderViewController: BaseViewController {
     @objc func onTapButton() {
         
         appendScheduleList = []
-        subIdx = choicedCells.enumerated().compactMap { (idx, element) in element ? idx : nil }
+        submitIndexList = choicedCells.enumerated().compactMap { (idx, element) in element ? idx : nil }
         
-        for idx in subIdx {
+        for index in submitIndexList {
             appendScheduleList.append(ScheduleInfo(
-                consultingDate: dateIndexToString(index: idx),
-                startTime: timeIndexToString(index: idx),
+                consultingDate: dateIndexToString(index: index),
+                startTime: timeIndexToString(index: index),
                 isReserved: false))
         }
         

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ParentsCalenderViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ParentsCalenderViewController.swift
@@ -92,9 +92,9 @@ class ParentsCalenderViewController: BaseViewController {
     }
     
     func timeIndexToString(index: Int) -> String {
-        
-        let hour = String(14 + (index/numberOfRow)/2) //14시 + @
-        let minute: String = (index/numberOfRow) % 2 == 0 ? "00" : "30" //짝수줄은 정각, 홀수줄은 30분
+        let rowInCalender = index/numberOfRow
+        let hour = String(14 + (rowInCalender)/2) //14시 + @
+        let minute: String = (rowInCalender) % 2 == 0 ? "00" : "30" //짝수줄은 정각, 홀수줄은 30분
         startTime = hour+"시"+minute+"분"
         
         return startTime

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Consultation/Cell/CalenderTabelViewCell.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Consultation/Cell/CalenderTabelViewCell.swift
@@ -10,19 +10,7 @@ import UIKit
 class CalenderTableViewCell: BaseTableViewCell {
     
     // MARK: - Properties
-    private var isChecked: Bool = false {
-        didSet {
-            checkBox.tintColor = isChecked ? .red : .gray
-        }
-    }
-
     static let identifier = "CalenderTableViewCell"
-    
-    private let checkBox: UIImageView = {
-        let imageView = UIImageView()
-        imageView.translatesAutoresizingMaskIntoConstraints = false
-        return imageView
-    }()
     
     private let messageInfo: UILabel = {
        let messageInfo = UILabel()
@@ -60,12 +48,6 @@ class CalenderTableViewCell: BaseTableViewCell {
         content.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20).isActive = true
         
     }
-    
-    override func configUI() {
-        checkBox.image = UIImage(systemName: "flame.fill")
-        checkBox.tintColor = .gray
-
-    }
 
     func configure(childName: String, schedule: Schedule) {
         
@@ -82,11 +64,6 @@ class CalenderTableViewCell: BaseTableViewCell {
         
         messageInfo.text = "\(childName) / \(schedule.content)"
         content.text = "\(dateAndTime)"
-        
-    }
-    
-    func changeState() {
-        self.isChecked.toggle()
         
     }
 }

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Consultation/Cell/CalenderTabelViewCell.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Consultation/Cell/CalenderTabelViewCell.swift
@@ -1,0 +1,92 @@
+//
+//  MessageTableViewCell.swift
+//  Gajeongtongsin
+//
+//  Created by uiskim on 2022/07/23.
+//
+
+import UIKit
+
+class CalenderTableViewCell: BaseTableViewCell {
+    
+    // MARK: - Properties
+    private var isChecked: Bool = false {
+        didSet {
+            checkBox.tintColor = isChecked ? .red : .gray
+        }
+    }
+
+    static let identifier = "CalenderTableViewCell"
+    
+    private let checkBox: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+    
+    private let messageInfo: UILabel = {
+       let messageInfo = UILabel()
+        messageInfo.translatesAutoresizingMaskIntoConstraints = false
+        messageInfo.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
+        messageInfo.textColor = UIColor.black
+        return messageInfo
+    }()
+    
+    private let content: UILabel = {
+       let content = UILabel()
+        content.translatesAutoresizingMaskIntoConstraints = false
+        content.font = UIFont.systemFont(ofSize: 10, weight: .semibold)
+        content.textColor = UIColor.black
+        return content
+    }()
+    
+    // MARK: - Init
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Funcs
+    override func render() {
+        contentView.addSubview(messageInfo)
+        messageInfo.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 28).isActive = true
+        messageInfo.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20).isActive = true
+        
+        contentView.addSubview(content)
+        content.topAnchor.constraint(equalTo: messageInfo.bottomAnchor, constant: 10).isActive = true
+        content.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20).isActive = true
+        
+    }
+    
+    override func configUI() {
+        checkBox.image = UIImage(systemName: "flame.fill")
+        checkBox.tintColor = .gray
+
+    }
+
+    func configure(childName: String, schedule: Schedule) {
+        
+        var dateAndTime: String {
+            var dateAndTime: String = ""
+            var specificSchedule: String = ""
+            
+            schedule.scheduleList.forEach {
+                specificSchedule = $0.consultingDate+", "+$0.startTime
+                dateAndTime += " | "+specificSchedule
+            }
+            return dateAndTime
+        }
+        
+        messageInfo.text = "\(childName) / \(schedule.content)"
+        content.text = "\(dateAndTime)"
+        
+    }
+    
+    func changeState() {
+        self.isChecked.toggle()
+        
+    }
+}

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Consultation/Cell/TestB.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Consultation/Cell/TestB.swift
@@ -1,8 +1,0 @@
-//
-//  TestB.swift
-//  Gajeongtongsin
-//
-//  Created by DaeSeong on 2022/07/16.
-//
-
-import Foundation

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Consultation/ConsultationViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Consultation/ConsultationViewController.swift
@@ -8,25 +8,21 @@
 import UIKit
 
 class ConsultationViewController: BaseViewController {
-      
     
     //MARK: - Properties
     private var choicedCells: [Bool] = Array(repeating: false, count:30)
-    private var displayData: [teacherCalenderData] = []
+    private var displayData: [TeacherCalenderData] = []
     private var cellColor: UIColor = .gray
     private var clickedCell: Int?
     private var selectedIndex: Int?
     private var parentId: Int?
-    
-//    private var acceptedData: [Schedule] = []
-    
     
     //다음 일주일의 날짜 리스트를 반환해주는 함수, 아래의 dayIndex 함수에 사용함
     var nextWeek: [String] {
         let formatter = DateFormatter()
         formatter.dateFormat = "MMM-dd"
         var nextWeek = [String]()
-        
+         
         for dayCount in 0..<weekDays+2 { //주말 이틀 추가(weekDays==5)
 //            let dayAdded = (86400 * (2+dayCount-todayOfTheWeek +7)) //캘린더뷰가 다음주를 표시하는 경우 +7
             let dayAdded = (86400 * (2+dayCount-todayOfTheWeek))
@@ -38,11 +34,10 @@ class ConsultationViewController: BaseViewController {
     
     //mockdata의 상담예약 관련 데이터를 teacherCalenderDate에 불러오는 함수
     
-    private var calenderData: [teacherCalenderData] = [
-        teacherCalenderData(parentIds: 0, calenderIndex: [], cellColor: .green),
-        teacherCalenderData(parentIds: 1, calenderIndex: [], cellColor: .blue),
-        teacherCalenderData(parentIds: 2, calenderIndex: [], cellColor: .red)]
-    
+    private var calenderData: [TeacherCalenderData] = [
+        TeacherCalenderData(parentIds: 0, calenderIndex: [], cellColor: .green),
+        TeacherCalenderData(parentIds: 1, calenderIndex: [], cellColor: .blue),
+        TeacherCalenderData(parentIds: 2, calenderIndex: [], cellColor: .red)]
     
     // 캘린더뷰
     private let calenderView:  UICollectionView = {
@@ -52,7 +47,6 @@ class ConsultationViewController: BaseViewController {
         collectionView.translatesAutoresizingMaskIntoConstraints = false //필수 !!
         return collectionView
     }()
-
     
     // 학부모1 신청내역 보기
     private let par1: UIButton = {
@@ -93,17 +87,17 @@ class ConsultationViewController: BaseViewController {
     
     //MARK: - Funcs
     
-    func acceptedData() -> [teacherCalenderData] {
-        var acceptedData:[teacherCalenderData] = []
+    func acceptedData() -> [TeacherCalenderData] {
+        var acceptedData: [TeacherCalenderData] = []
         var calenderIndex: [Int] = []
 
-        for parentIdx in 0..<mainTeacher.parentUserIds.count {
+        for parentIndex in 0..<mainTeacher.parentUserIds.count {
             calenderIndex = []
             
-            for i in 0..<mainTeacher.parentUserIds[parentIdx].schedules[0].scheduleList.count{ //하단 funcs 참고
-                if mainTeacher.parentUserIds[parentIdx].schedules[0].scheduleList[i].isReserved {
-                    acceptedData.append(calenderData[i])
-                    calenderIndex.append(timeStringToIndex(parentUserIds: parentIdx)[i] * weekDays + dateStringToIndex(parentUserIds: parentIdx)[i])
+            for index in 0..<mainTeacher.parentUserIds[parentIndex].schedules[0].scheduleList.count { //하단 funcs 참고
+                if mainTeacher.parentUserIds[parentIndex].schedules[0].scheduleList[index].isReserved {
+                    acceptedData.append(calenderData[index])
+                    calenderIndex.append(timeStringToIndex(parentUserIds: parentIndex)[index] * weekDays + dateStringToIndex(parentUserIds: parentIndex)[index])
                     acceptedData[acceptedData.count-1].calenderIndex = calenderIndex
                 }
             }
@@ -112,9 +106,9 @@ class ConsultationViewController: BaseViewController {
     }
     
     //모든 신청 예약 데이터를 인덱스로 만들어주는 함수 : 연산 프로퍼티로 하기에는 다시 입력/로드되어야 하는 경우가 있어 함수로 수정
-    func submittedData() -> [teacherCalenderData] {
+    func submittedData() -> [TeacherCalenderData] {
         var calenderIndex: [Int] = []
-
+        
         for parentIdx in 0..<mainTeacher.parentUserIds.count {
             calenderIndex = []
             for i in 0..<mainTeacher.parentUserIds[parentIdx].schedules[0].scheduleList.count{ //하단 funcs 참고
@@ -161,6 +155,7 @@ class ConsultationViewController: BaseViewController {
     @objc func par1OnTapButton() {
         displayData = acceptedData()
         displayData.append(submittedData()[0])
+        print(acceptedData())
         
         calenderView.reloadData()
     }
@@ -181,7 +176,7 @@ class ConsultationViewController: BaseViewController {
     
     override func render() {
         view.addSubview(calenderView)
-        calenderView.topAnchor.constraint(equalTo: view.topAnchor, constant: 200).isActive = true
+        calenderView.topAnchor.constraint(equalTo: view.topAnchor, constant: 100).isActive = true
         calenderView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
         calenderView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 50).isActive = true
         calenderView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -50).isActive = true
@@ -207,7 +202,6 @@ class ConsultationViewController: BaseViewController {
 //MARK: - Extensions
 
 extension ConsultationViewController: UICollectionViewDelegate{
-     
    
     //cell 로드
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Consultation/ConsultationViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Consultation/ConsultationViewController.swift
@@ -62,22 +62,7 @@ class ConsultationViewController: BaseViewController {
         return collectionView
     }()
     
-    // 학부모1 신청내역 보기
-    private let par1: UIButton = {
-        let button = UIButton()
-        button.setTitle("학부모 1", for: .normal)
-        button.setTitleColor(.black, for: .normal)
-        button.translatesAutoresizingMaskIntoConstraints = false
-        return button
-    }()
-    // 학부모2 신청내역 보기
-    private let par2: UIButton = {
-        let button = UIButton()
-        button.setTitle("학부모 2", for: .normal)
-        button.setTitleColor(.black, for: .normal)
-        button.translatesAutoresizingMaskIntoConstraints = false
-        return button
-    }()
+    
     // 전체 신청내역 보기
     private let seeAll: UIButton = {
         let button = UIButton()
@@ -96,9 +81,6 @@ class ConsultationViewController: BaseViewController {
         tableView.dataSource = self
         tableView.delegate = self
 
-        
-        par1.addTarget(self, action: #selector(par1OnTapButton), for: .touchUpInside)
-        par2.addTarget(self, action: #selector(par2OnTapButton), for: .touchUpInside)
         seeAll.addTarget(self, action: #selector(seeAllOnTapButton), for: .touchUpInside)
     }
     
@@ -117,6 +99,7 @@ class ConsultationViewController: BaseViewController {
                     calenderIndex.append(timeStringToIndex(parentUserIds: parentIndex)[index] * weekDays + dateStringToIndex(parentUserIds: parentIndex)[index])
                     acceptedData[acceptedData.count-1].calenderIndex = calenderIndex
                 }
+                
             }
         }
         return acceptedData
@@ -136,6 +119,8 @@ class ConsultationViewController: BaseViewController {
         }
         return calenderData
     }
+    
+    
     
     //선택한 학부모의 신청 요일(날자)를 리스트로 반환해주는 함수
     func dateStringToIndex(parentUserIds: Int) -> [Int] {
@@ -198,23 +183,15 @@ class ConsultationViewController: BaseViewController {
         calenderView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 50).isActive = true
         calenderView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -50).isActive = true
         
-        view.addSubview(par1)
-        par1.topAnchor.constraint(equalTo: calenderView.topAnchor, constant: 320).isActive = true
-        par1.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 50).isActive = true
-        
-        view.addSubview(par2)
-        par2.topAnchor.constraint(equalTo: calenderView.topAnchor, constant: 370).isActive = true
-        par2.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 50).isActive = true
-        
         view.addSubview(seeAll)
-        seeAll.topAnchor.constraint(equalTo: calenderView.topAnchor, constant: 420).isActive = true
+        seeAll.topAnchor.constraint(equalTo: calenderView.topAnchor, constant: 320).isActive = true
         seeAll.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 50).isActive = true
         
         view.addSubview(tableView)
-        tableView.topAnchor.constraint(equalTo: calenderView.topAnchor, constant: 450).isActive = true
+        tableView.topAnchor.constraint(equalTo: calenderView.topAnchor, constant: 350).isActive = true
         tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
-        tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
-        tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
+        tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 30).isActive = true
+        tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -30).isActive = true
     }
 
     override func configUI() {
@@ -255,14 +232,13 @@ extension ConsultationViewController: UICollectionViewDelegate{
             mainTeacher.parentUserIds[parentId!].schedules[0].scheduleList = [mainTeacher.parentUserIds[parentId!].schedules[0].scheduleList[selectedIndex!]]
             mainTeacher.parentUserIds[parentId!].schedules[0].scheduleList[0].isReserved = true
             
-            calenderData[parentId!].cellColor = .white
+            calenderData[parentId!].cellColor = .borderGray
+            
 
             //onTapButton 함수 실행 -> 수정된 스케줄 데이터 다시 불러오고 확정된 스케줄만 다시 그려줌
-            switch parentId {
-            case 0: par1OnTapButton()
-            case 1: par2OnTapButton()
-            default: break
-            }
+            displayData = acceptedData()
+            displayData.append(submittedData()[parentId!])
+            calenderView.reloadData()
             
             clickedCell = nil
             calenderView.reloadData()
@@ -335,12 +311,11 @@ extension ConsultationViewController: UITableViewDataSource {
 
 
 extension ConsultationViewController: UITableViewDelegate {
+    
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         displayData = acceptedData()
         displayData.append(submittedData()[indexPath.item])
-        print(acceptedData())
         
         calenderView.reloadData()
-        
     }
 }


### PR DESCRIPTION
## 🍏 관련 이슈
<!-- 해당 PR과 관련된 이슈를 링크해주세요. -->
#43 

## 🍏 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
교사 캘린더뷰의 MVP 거의 모든 기능 구현완료
기능 확장(슬롯 개인화, 다음주 확장 등)이 남음
이전 PR 수정사항 반영

테이블뷰 목록에 학부모의 신청내용과 시간(3개)가 뜨고, 한 cell을 선택하면 해당 셀의 예약내역이 캘린더뷰에 표시됨.
표시된 3개 슬롯 중 하나 선택하면 확정버튼 뜨고 다시 누르면 확정 및 슬롯 닫힘, 테이블뷰 새로고침(시간 하나만 표시)
테이블뷰 혹은 전체보기를 선택한 상태에서 화면의 빈 여백을 누르면 선택이 취소됨

https://user-images.githubusercontent.com/70618615/181193190-f0e07692-fa19-48ea-97b0-00e81c8bc22f.mp4


## 🍏 다음으로 진행될 작업
 - [ ] 현재까지 코드 리팩터링

## 🍏 주의사항
- **빈 폴더 있는지 확인하기!!**
- **파일,폴더 위치 및 이동 하지말기!!**
