### PR TITLE
[ADD] 메세지 보낸날짜를 section별로 분리해서 Teacher MessageView로 띄우기

### DIFF
--- a/Gajeongtongsin/Gajeongtongsin.xcodeproj/project.pbxproj
+++ b/Gajeongtongsin/Gajeongtongsin.xcodeproj/project.pbxproj
@@ -46,6 +46,8 @@
 		8C3DD251288A63CF00A3E9C6 /* SentMessageListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C3DD250288A63CF00A3E9C6 /* SentMessageListViewController.swift */; };
 		8C40E867288B7BC100DECACA /* SentMessageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C40E866288B7BC100DECACA /* SentMessageTableViewCell.swift */; };
 		8CBD1521288F900500510610 /* ScheduleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CBD1520288F900500510610 /* ScheduleTableViewCell.swift */; };
+		C01FA466289406B300A1E4DB /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C01FA465289406B300A1E4DB /* Date+Extension.swift */; };
+		C01FA468289406C700A1E4DB /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C01FA467289406C700A1E4DB /* String+Extension.swift */; };
 		C04B547F2887C6250097EE88 /* MockData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04B547E2887C6250097EE88 /* MockData.swift */; };
 		C054017D288D04F6002BF33B /* NotificationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C054017C288D04F6002BF33B /* NotificationViewController.swift */; };
 		C054017F288D0520002BF33B /* NotificationTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C054017E288D0520002BF33B /* NotificationTableViewCell.swift */; };
@@ -100,6 +102,8 @@
 		8C3DD250288A63CF00A3E9C6 /* SentMessageListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentMessageListViewController.swift; sourceTree = "<group>"; };
 		8C40E866288B7BC100DECACA /* SentMessageTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentMessageTableViewCell.swift; sourceTree = "<group>"; };
 		8CBD1520288F900500510610 /* ScheduleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleTableViewCell.swift; sourceTree = "<group>"; };
+		C01FA465289406B300A1E4DB /* Date+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extension.swift"; sourceTree = "<group>"; };
+		C01FA467289406C700A1E4DB /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		C04B547E2887C6250097EE88 /* MockData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockData.swift; sourceTree = "<group>"; };
 		C054017C288D04F6002BF33B /* NotificationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationViewController.swift; sourceTree = "<group>"; };
 		C054017E288D0520002BF33B /* NotificationTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationTableViewCell.swift; sourceTree = "<group>"; };
@@ -235,6 +239,8 @@
 			isa = PBXGroup;
 			children = (
 				35958382288299AE002B6873 /* UIColor+Extension.swift */,
+				C01FA465289406B300A1E4DB /* Date+Extension.swift */,
+				C01FA467289406C700A1E4DB /* String+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -534,6 +540,7 @@
 				C056F6AD288B0A770070EED5 /* MessageVIewController.swift in Sources */,
 				C0B4A4302890E7AA001DC86C /* CutomNavigationBar.swift in Sources */,
 				35171CFE28828C930059F297 /* AppDelegate.swift in Sources */,
+				C01FA468289406C700A1E4DB /* String+Extension.swift in Sources */,
 				359583A228829D93002B6873 /* TestK.swift in Sources */,
 				8C3DD251288A63CF00A3E9C6 /* SentMessageListViewController.swift in Sources */,
 				C0B4A4322890E8B9001DC86C /* CutomNavigationBarDelegate.swift in Sources */,
@@ -563,6 +570,7 @@
 				35958383288299AE002B6873 /* UIColor+Extension.swift in Sources */,
 				C0DFFC032885DE32009A1563 /* Message.swift in Sources */,
 				3595837D288297E7002B6873 /* ReceivingViewController.swift in Sources */,
+				C01FA466289406B300A1E4DB /* Date+Extension.swift in Sources */,
 				359583A82882A6F7002B6873 /* Constants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Gajeongtongsin/Gajeongtongsin/Global/Extension/Date+Extension.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Global/Extension/Date+Extension.swift
@@ -1,0 +1,17 @@
+//
+//  Date+Extension.swift
+//  Gajeongtongsin
+//
+//  Created by uiskim on 2022/07/29.
+//
+
+import Foundation
+
+extension Date {
+    func toString() -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "MM월dd일"
+        dateFormatter.timeZone = TimeZone(identifier: "ko_KR")
+        return dateFormatter.string(from: self)
+    }
+}

--- a/Gajeongtongsin/Gajeongtongsin/Global/Extension/String+Extension.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Global/Extension/String+Extension.swift
@@ -1,0 +1,19 @@
+//
+//  String+Extension.swift
+//  Gajeongtongsin
+//
+//  Created by uiskim on 2022/07/29.
+//
+
+import Foundation
+
+extension String {
+    func toDate() -> Date? {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        dateFormatter.timeZone = TimeZone(identifier: "ko_KR")
+
+        guard let date = dateFormatter.date(from: self) else {return nil}
+        return date
+    }
+}

--- a/Gajeongtongsin/Gajeongtongsin/Global/Extension/UIColor+Extension.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Global/Extension/UIColor+Extension.swift
@@ -62,7 +62,7 @@ extension String {
 extension Date {
     func toString() -> String {
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
+        dateFormatter.dateFormat = "MM월dd일"
         dateFormatter.timeZone = TimeZone(identifier: "ko_KR")
         return dateFormatter.string(from: self)
     }

--- a/Gajeongtongsin/Gajeongtongsin/Global/Extension/UIColor+Extension.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Global/Extension/UIColor+Extension.swift
@@ -58,3 +58,12 @@ extension String {
         return date
     }
 }
+
+extension Date {
+    func toString() -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        dateFormatter.timeZone = TimeZone(identifier: "ko_KR")
+        return dateFormatter.string(from: self)
+    }
+}

--- a/Gajeongtongsin/Gajeongtongsin/Global/Extension/UIColor+Extension.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Global/Extension/UIColor+Extension.swift
@@ -47,23 +47,3 @@ extension UIColor {
             blue: CGFloat(rgbValue & 0x0000FF) / 255.0, alpha: alpha)
     }
 }
-
-extension String {
-    func toDate() -> Date? {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
-        dateFormatter.timeZone = TimeZone(identifier: "ko_KR")
-
-        guard let date = dateFormatter.date(from: self) else {return nil}
-        return date
-    }
-}
-
-extension Date {
-    func toString() -> String {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "MM월dd일"
-        dateFormatter.timeZone = TimeZone(identifier: "ko_KR")
-        return dateFormatter.string(from: self)
-    }
-}

--- a/Gajeongtongsin/Gajeongtongsin/Global/Extension/UIColor+Extension.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Global/Extension/UIColor+Extension.swift
@@ -47,3 +47,14 @@ extension UIColor {
             blue: CGFloat(rgbValue & 0x0000FF) / 255.0, alpha: alpha)
     }
 }
+
+extension String {
+    func toDate() -> Date? {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        dateFormatter.timeZone = TimeZone(identifier: "ko_KR")
+
+        guard let date = dateFormatter.date(from: self) else {return nil}
+        return date
+    }
+}

--- a/Gajeongtongsin/Gajeongtongsin/Global/Literal/MockData.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Global/Literal/MockData.swift
@@ -15,18 +15,18 @@ var parent2 = ParentUser(id: "2", sendingMessages: messageList2, childName: "부
 var parent3 = ParentUser(id: "3", sendingMessages: messageList3, childName: "최히로", schedules: scheduleList3)
 
 var messageList1 = [
-    Message(type: .absence, sentDate: "실시간", expectedDate: "7월21일", content: "김유쓰배아픔", isCompleted: false),
-    Message(type: .earlyLeave, sentDate: "실시간", expectedDate: "7월22일", content: "김유쓰놀이공원", isCompleted: false)
+    Message(type: .absence, sentDate: "2022-03-01".toDate()!, expectedDate: "7월21일", content: "김유쓰배아픔", isCompleted: false),
+    Message(type: .earlyLeave, sentDate: "2022-03-04".toDate()!, expectedDate: "7월22일", content: "김유쓰놀이공원", isCompleted: false),
 ]
 
 var messageList2 = [
-    Message(type: .absence, sentDate: "실시간", expectedDate: "7월23일", content: "부니카제주도", isCompleted: false),
-    Message(type: .earlyLeave, sentDate: "실시간", expectedDate: "7월24일", content: "부니카서울", isCompleted: false)
-    ]
+    Message(type: .absence, sentDate: "2022-03-04".toDate()!, expectedDate: "7월23일", content: "부니카제주도", isCompleted: false),
+    Message(type: .earlyLeave, sentDate: "2022-03-12".toDate()!, expectedDate: "7월24일", content: "부니카서울", isCompleted: false)
+]
 
 var messageList3 = [
-    Message(type: .absence, sentDate: "실시간", expectedDate: "7월25일", content: "최히로소개팅", isCompleted: false),
-    Message(type: .earlyLeave, sentDate: "실시간", expectedDate: "7월26일", content: "최히로레브랑데이트", isCompleted: false)
+    Message(type: .absence, sentDate: "2022-03-01".toDate()!, expectedDate: "7월25일", content: "최히로소개팅", isCompleted: false),
+    Message(type: .earlyLeave, sentDate: "2022-03-07".toDate()!, expectedDate: "7월26일", content: "최히로레브랑데이트", isCompleted: false)
 ]
 
 var scheduleList1 = [
@@ -71,3 +71,4 @@ let noti8 = Notification(id: "2", postId: "22", type: .reservation, childName: "
 let noti9 = Notification(id: "3", postId: "33", type: .message, childName: "최히로", content: "99")
 let noti10 = Notification(id: "3", postId: "33", type: .message, childName: "최히로", content: "1010")
 let noti11 = Notification(id: "3", postId: "33", type: .reservation, childName: "최히로", content: "1111")
+

--- a/Gajeongtongsin/Gajeongtongsin/Global/Literal/MockData.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Global/Literal/MockData.swift
@@ -17,16 +17,19 @@ var parent3 = ParentUser(id: "3", sendingMessages: messageList3, childName: "최
 var messageList1 = [
     Message(type: .absence, sentDate: "2022-03-01".toDate()!, expectedDate: "7월21일", content: "김유쓰배아픔", isCompleted: false),
     Message(type: .earlyLeave, sentDate: "2022-03-04".toDate()!, expectedDate: "7월22일", content: "김유쓰놀이공원", isCompleted: false),
+    Message(type: .earlyLeave, sentDate: "2022-03-19".toDate()!, expectedDate: "7월28일", content: "김유쓰할머니댁", isCompleted: false)
 ]
 
 var messageList2 = [
     Message(type: .absence, sentDate: "2022-03-04".toDate()!, expectedDate: "7월23일", content: "부니카제주도", isCompleted: false),
-    Message(type: .earlyLeave, sentDate: "2022-03-12".toDate()!, expectedDate: "7월24일", content: "부니카서울", isCompleted: false)
+    Message(type: .earlyLeave, sentDate: "2022-03-07".toDate()!, expectedDate: "7월24일", content: "부니카서울", isCompleted: false),
+    Message(type: .earlyLeave, sentDate: "2022-03-15".toDate()!, expectedDate: "7월24일", content: "부니카애플아카데미", isCompleted: false)
 ]
 
 var messageList3 = [
     Message(type: .absence, sentDate: "2022-03-01".toDate()!, expectedDate: "7월25일", content: "최히로소개팅", isCompleted: false),
-    Message(type: .earlyLeave, sentDate: "2022-03-07".toDate()!, expectedDate: "7월26일", content: "최히로레브랑데이트", isCompleted: false)
+    Message(type: .earlyLeave, sentDate: "2022-03-07".toDate()!, expectedDate: "7월26일", content: "최히로레브랑데이트", isCompleted: false),
+    Message(type: .earlyLeave, sentDate: "2022-03-15".toDate()!, expectedDate: "7월26일", content: "최히로번개만남", isCompleted: false)
 ]
 
 var scheduleList1 = [
@@ -71,4 +74,3 @@ let noti8 = Notification(id: "2", postId: "22", type: .reservation, childName: "
 let noti9 = Notification(id: "3", postId: "33", type: .message, childName: "최히로", content: "99")
 let noti10 = Notification(id: "3", postId: "33", type: .message, childName: "최히로", content: "1010")
 let noti11 = Notification(id: "3", postId: "33", type: .reservation, childName: "최히로", content: "1111")
-

--- a/Gajeongtongsin/Gajeongtongsin/Global/Literal/MockData.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Global/Literal/MockData.swift
@@ -15,21 +15,21 @@ var parent2 = ParentUser(id: "2", sendingMessages: messageList2, childName: "부
 var parent3 = ParentUser(id: "3", sendingMessages: messageList3, childName: "최히로", schedules: scheduleList3)
 
 var messageList1 = [
-    Message(type: .absence, sentDate: "2022-03-01".toDate()!, expectedDate: "7월21일", content: "김유쓰배아픔", isCompleted: false),
-    Message(type: .earlyLeave, sentDate: "2022-03-04".toDate()!, expectedDate: "7월22일", content: "김유쓰놀이공원", isCompleted: false),
-    Message(type: .earlyLeave, sentDate: "2022-03-19".toDate()!, expectedDate: "7월28일", content: "김유쓰할머니댁", isCompleted: false)
+    Message(type: .absence, sentDate: "2022-03-01", expectedDate: "7월21일", content: "김유쓰배아픔", isCompleted: false),
+    Message(type: .earlyLeave, sentDate: "2022-03-04", expectedDate: "7월22일", content: "김유쓰놀이공원", isCompleted: false),
+    Message(type: .earlyLeave, sentDate: "2022-03-19", expectedDate: "7월28일", content: "김유쓰할머니댁", isCompleted: false)
 ]
 
 var messageList2 = [
-    Message(type: .absence, sentDate: "2022-03-04".toDate()!, expectedDate: "7월23일", content: "부니카제주도", isCompleted: false),
-    Message(type: .earlyLeave, sentDate: "2022-03-07".toDate()!, expectedDate: "7월24일", content: "부니카서울", isCompleted: false),
-    Message(type: .earlyLeave, sentDate: "2022-03-15".toDate()!, expectedDate: "7월24일", content: "부니카애플아카데미", isCompleted: false)
+    Message(type: .absence, sentDate: "2022-03-04", expectedDate: "7월23일", content: "부니카제주도", isCompleted: false),
+    Message(type: .earlyLeave, sentDate: "2022-03-07", expectedDate: "7월24일", content: "부니카서울", isCompleted: false),
+    Message(type: .earlyLeave, sentDate: "2022-03-15", expectedDate: "7월24일", content: "부니카애플아카데미", isCompleted: false)
 ]
 
 var messageList3 = [
-    Message(type: .absence, sentDate: "2022-03-01".toDate()!, expectedDate: "7월25일", content: "최히로소개팅", isCompleted: false),
-    Message(type: .earlyLeave, sentDate: "2022-03-07".toDate()!, expectedDate: "7월26일", content: "최히로레브랑데이트", isCompleted: false),
-    Message(type: .earlyLeave, sentDate: "2022-03-15".toDate()!, expectedDate: "7월26일", content: "최히로번개만남", isCompleted: false)
+    Message(type: .absence, sentDate: "2022-03-01", expectedDate: "7월25일", content: "최히로소개팅", isCompleted: false),
+    Message(type: .earlyLeave, sentDate: "2022-03-07", expectedDate: "7월26일", content: "최히로레브랑데이트", isCompleted: false),
+    Message(type: .earlyLeave, sentDate: "2022-03-15", expectedDate: "7월26일", content: "최히로번개만남", isCompleted: false)
 ]
 
 var scheduleList1 = [

--- a/Gajeongtongsin/Gajeongtongsin/Models/Message.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Models/Message.swift
@@ -8,7 +8,7 @@
 import Foundation
 struct Message : Codable {
     let type: MessageType      //요구하는task(enum) -> 우선 조퇴랑 결석만
-    let sentDate: String       //메세지 보내는 시간
+    let sentDate: Date       //메세지 보내는 시간
     let expectedDate: String   //(->String)학부모가 요구하는(조퇴나 결석) 날짜
     let content: String        //메세지 내용
     let isCompleted: Bool      //task완료 여부(교사의 체크)

--- a/Gajeongtongsin/Gajeongtongsin/Models/Message.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Models/Message.swift
@@ -8,7 +8,7 @@
 import Foundation
 struct Message : Codable {
     let type: MessageType      //요구하는task(enum) -> 우선 조퇴랑 결석만
-    let sentDate: Date       //메세지 보내는 시간
+    let sentDate: String       //메세지 보내는 시간
     let expectedDate: String   //(->String)학부모가 요구하는(조퇴나 결석) 날짜
     let content: String        //메세지 내용
     let isCompleted: Bool      //task완료 여부(교사의 체크)
@@ -20,4 +20,4 @@ enum MessageType: String, Codable {
 }
 
 var messagesWithChildName = mainTeacher.parentUsers.flatMap({$0.getMessagesWithChildName()})
-var sortedMessages = chunkedMessages(messages: messagesWithChildName.sorted(by: {$0.message.sentDate < $1.message.sentDate}))
+var sortedMessages = chunkedMessages(messages: messagesWithChildName.sorted(by: {$0.message.sentDate > $1.message.sentDate}))

--- a/Gajeongtongsin/Gajeongtongsin/Models/Message.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Models/Message.swift
@@ -18,3 +18,6 @@ enum MessageType: String, Codable {
     case absence = "결석"
     case earlyLeave = "조퇴"
 }
+
+var messagesWithChildName = mainTeacher.parentUsers.flatMap({$0.getMessagesWithChildName()})
+var sortedMessages = chunkedMessages(messages: messagesWithChildName.sorted(by: {$0.message.sentDate < $1.message.sentDate}))

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SendingViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SendingViewController.swift
@@ -207,7 +207,7 @@ class SendingViewController: BaseViewController {
   
     @objc func sendMessage() {
         let newMsg = Message(type: msgType(),
-                             sentDate: "Date()",
+                             sentDate: "2022-03-21".toDate()!,
                              expectedDate: "\(datePicker.date)",
                              content: textFieldForReason.text ?? "",
                              isCompleted: false)

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SendingViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SendingViewController.swift
@@ -207,7 +207,7 @@ class SendingViewController: BaseViewController {
   
     @objc func sendMessage() {
         let newMsg = Message(type: msgType(),
-                             sentDate: "2022-03-21".toDate()!,
+                             sentDate: "2022-03-21",
                              expectedDate: "\(datePicker.date)",
                              content: textFieldForReason.text ?? "",
                              isCompleted: false)

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/Cell/MessageTableViewCell.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/Cell/MessageTableViewCell.swift
@@ -78,6 +78,12 @@ class MessageTableViewCell: BaseTableViewCell {
 
     }
     
+    func aa(section: Int, row: Int) {
+        let aa: MessagesWithChildName = sortedMessages[section]
+        messageInfo.text = "\(aa[row].childName) / \(aa[row].message.type.rawValue) / \(aa[row].message.expectedDate)"
+        content.text = "\(aa[row].message.content)"
+    }
+    
     func changeState() {
         self.isChecked.toggle()
         

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/Cell/MessageTableViewCell.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/Cell/MessageTableViewCell.swift
@@ -10,28 +10,30 @@ import UIKit
 class MessageTableViewCell: BaseTableViewCell {
     
     // MARK: - Properties
-    private var isChecked: Bool = false {
+    var isChecked: Bool = false {
         didSet {
-            checkBox.tintColor = isChecked ? .red : .gray
+            if isChecked == true {
+                checkBox.backgroundColor = UIColor(hex: "#F0E5CF")
+                stateLabel.text = "처리완료"
+                stateLabel.textColor = UIColor(hex: "#666569")
+            }
         }
     }
 
     static let identifier = "ProfileTableViewCell"
     
     private let checkBox: UIImageView = {
-        let imageView = UIImageView()
-        imageView.frame = CGRect(x: 274, y: 18, width: 100, height: 30)
-        imageView.backgroundColor = .red
-        imageView.layer.cornerRadius = 10
-        return imageView
+        let checkBox = UIImageView()
+        checkBox.frame = CGRect(x: 274, y: 18, width: 100, height: 30)
+        checkBox.backgroundColor = UIColor(hex: "#415D95")
+        checkBox.layer.cornerRadius = 10
+        return checkBox
     }()
     
     private let stateLabel: UILabel = {
         let stateLabel = UILabel()
         stateLabel.translatesAutoresizingMaskIntoConstraints = false
-        stateLabel.text = "처리하기"
         stateLabel.textAlignment = .center
-        stateLabel.textColor = .white
         stateLabel.font = UIFont.systemFont(ofSize: 16)
         return stateLabel
     }()
@@ -39,7 +41,7 @@ class MessageTableViewCell: BaseTableViewCell {
     private let messageInfo: UILabel = {
        let messageInfo = UILabel()
         messageInfo.translatesAutoresizingMaskIntoConstraints = false
-        messageInfo.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
+        messageInfo.font = UIFont.systemFont(ofSize: 17, weight: .medium)
         messageInfo.textColor = UIColor.black
         return messageInfo
     }()
@@ -47,7 +49,7 @@ class MessageTableViewCell: BaseTableViewCell {
     private let content: UILabel = {
        let content = UILabel()
         content.translatesAutoresizingMaskIntoConstraints = false
-        content.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
+        content.font = UIFont.systemFont(ofSize: 17, weight: .medium)
         content.textColor = UIColor.black
         return content
     }()
@@ -64,7 +66,7 @@ class MessageTableViewCell: BaseTableViewCell {
     // MARK: - Funcs
     override func render() {
         contentView.addSubview(messageInfo)
-        messageInfo.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 28).isActive = true
+        messageInfo.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 9).isActive = true
         messageInfo.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20).isActive = true
         
         contentView.addSubview(content)
@@ -76,26 +78,23 @@ class MessageTableViewCell: BaseTableViewCell {
         stateLabel.centerYAnchor.constraint(equalTo: checkBox.centerYAnchor).isActive = true
         
         contentView.addSubview(checkBox)
-//        checkBox.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 18).isActive = true
-//        checkBox.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 274).isActive = true
-
         
     }
     
     override func configUI() {
-        checkBox.tintColor = .gray
-
+        stateLabel.text = "처리하기"
+        stateLabel.textColor = .white
     }
 
     
-    func configure(section: Int, row: Int) {
-        let aa: MessagesWithChildName = sortedMessages[section]
-        messageInfo.text = "\(aa[row].childName) / \(aa[row].message.type.rawValue) / \(aa[row].message.expectedDate)"
-        content.text = "\(aa[row].message.content)"
+    func configure(indexPath: IndexPath) {
+        let message: MessagesWithChildName = sortedMessages[indexPath.section]
+        messageInfo.text = "\(message[indexPath.row].message.expectedDate) \(message[indexPath.row].message.type.rawValue) \(message[indexPath.row].childName)"
+        content.text = "\(message[indexPath.row].message.content)"
     }
     
     func changeState() {
-        self.isChecked.toggle()
+        self.isChecked = true
         
     }
 }

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/Cell/MessageTableViewCell.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/Cell/MessageTableViewCell.swift
@@ -20,8 +20,20 @@ class MessageTableViewCell: BaseTableViewCell {
     
     private let checkBox: UIImageView = {
         let imageView = UIImageView()
-        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.frame = CGRect(x: 274, y: 18, width: 100, height: 30)
+        imageView.backgroundColor = .red
+        imageView.layer.cornerRadius = 10
         return imageView
+    }()
+    
+    private let stateLabel: UILabel = {
+        let stateLabel = UILabel()
+        stateLabel.translatesAutoresizingMaskIntoConstraints = false
+        stateLabel.text = "처리하기"
+        stateLabel.textAlignment = .center
+        stateLabel.textColor = .white
+        stateLabel.font = UIFont.systemFont(ofSize: 16)
+        return stateLabel
     }()
     
     private let messageInfo: UILabel = {
@@ -59,15 +71,18 @@ class MessageTableViewCell: BaseTableViewCell {
         content.topAnchor.constraint(equalTo: messageInfo.bottomAnchor, constant: 10).isActive = true
         content.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20).isActive = true
         
+        checkBox.addSubview(stateLabel)
+        stateLabel.centerXAnchor.constraint(equalTo: checkBox.centerXAnchor).isActive = true
+        stateLabel.centerYAnchor.constraint(equalTo: checkBox.centerYAnchor).isActive = true
+        
         contentView.addSubview(checkBox)
-        checkBox.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -30).isActive = true
-        checkBox.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 40).isActive = true
+//        checkBox.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 18).isActive = true
+//        checkBox.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 274).isActive = true
 
         
     }
     
     override func configUI() {
-        checkBox.image = UIImage(systemName: "flame.fill")
         checkBox.tintColor = .gray
 
     }

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/Cell/MessageTableViewCell.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/Cell/MessageTableViewCell.swift
@@ -41,7 +41,7 @@ class MessageTableViewCell: BaseTableViewCell {
     private let messageInfo: UILabel = {
        let messageInfo = UILabel()
         messageInfo.translatesAutoresizingMaskIntoConstraints = false
-        messageInfo.font = UIFont.systemFont(ofSize: 17, weight: .medium)
+        messageInfo.font = UIFont.systemFont(ofSize: 17, weight: .regular)
         messageInfo.textColor = UIColor.black
         return messageInfo
     }()
@@ -49,7 +49,7 @@ class MessageTableViewCell: BaseTableViewCell {
     private let content: UILabel = {
        let content = UILabel()
         content.translatesAutoresizingMaskIntoConstraints = false
-        content.font = UIFont.systemFont(ofSize: 17, weight: .medium)
+        content.font = UIFont.systemFont(ofSize: 17, weight: .regular)
         content.textColor = UIColor.black
         return content
     }()

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/Cell/MessageTableViewCell.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/Cell/MessageTableViewCell.swift
@@ -72,13 +72,8 @@ class MessageTableViewCell: BaseTableViewCell {
 
     }
 
-    func configure(childName: String, message: Message) {
-        messageInfo.text = "\(childName) / \(message.type.rawValue) / \(message.expectedDate)"
-        content.text = "\(message.content)"
-
-    }
     
-    func aa(section: Int, row: Int) {
+    func configure(section: Int, row: Int) {
         let aa: MessagesWithChildName = sortedMessages[section]
         messageInfo.text = "\(aa[row].childName) / \(aa[row].message.type.rawValue) / \(aa[row].message.expectedDate)"
         content.text = "\(aa[row].message.content)"

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/MessageVIewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/MessageVIewController.swift
@@ -64,7 +64,7 @@ extension MessageViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: MessageTableViewCell.identifier, for: indexPath) as? MessageTableViewCell else { return UITableViewCell()}
     
-        cell.configure(section: indexPath.section, row: indexPath.row)
+        cell.configure(indexPath: indexPath)
         
         return cell
     }
@@ -78,6 +78,7 @@ extension MessageViewController: UITableViewDataSource {
 extension MessageViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
+        let clickedCell = tableView.cellForRow(at: indexPath) as? MessageTableViewCell
         let alert = UIAlertController(title: "처리완료하시겠습니까?", message: "확인을누르면 블라블라", preferredStyle: .alert)
         let cancelAction = UIAlertAction(title: "취소", style: .cancel)
         let okayAction = UIAlertAction(title: "확인", style: .default) { _ in
@@ -86,7 +87,10 @@ extension MessageViewController: UITableViewDelegate {
         }
         alert.addAction(cancelAction)
         alert.addAction(okayAction)
-        present(alert, animated: true, completion: nil)
+        
+        if clickedCell?.isChecked == false {
+            present(alert, animated: true, completion: nil)
+        }
     }
 }
 

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/MessageVIewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/MessageVIewController.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+typealias MessagesWithChildName = [(childName: String, message: Message)]
+
 class MessageViewController: BaseViewController {
     
     // MARK: - Properties
@@ -42,6 +44,23 @@ class MessageViewController: BaseViewController {
         self.navigationItem.title = "수신내역"
         self.navigationController?.navigationBar.tintColor = .black
         self.navigationController?.navigationBar.prefersLargeTitles = true
+    }
+    
+    func chunkedMessages(_ messages: MessagesWithChildName) -> [MessagesWithChildName] {
+        var messagesByDate: [MessagesWithChildName] = []
+        var currentDateMessages: MessagesWithChildName = []
+        
+        for message in messagesWithChildName {
+            if let lastElement = currentDateMessages.last {
+                if lastElement.message.sentDate != message.message.sentDate {
+                    messagesByDate.append(currentDateMessages)
+                    currentDateMessages = []
+                }
+            }
+            currentDateMessages.append(message)
+        }
+        return messagesByDate
+        
     }
 
 }
@@ -82,27 +101,3 @@ extension MessageViewController: UITableViewDelegate {
     }
 }
 
-//MARK: Chunk Logic Extension
-extension TeacherUser {
-    private var sortedMessage: [Message] {
-        return parentUsers.flatMap({$0.sendingMessages}).sorted(by: {$0.sentDate < $1.sentDate})
-    }
-    
-    var messagesByDate: [[Message]] {
-        var messagesByDate: [[Message]] = []
-        var currentDateMessages: [Message] = []
-        
-        for message in sortedMessage {
-            if let lastElement = currentDateMessages.last {
-                if lastElement.sentDate != message.sentDate {
-                    messagesByDate.append(currentDateMessages)
-                    currentDateMessages = []
-                }
-            }
-            
-            currentDateMessages.append(message)
-        }
-        
-        return messagesByDate
-    }
-}

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/MessageVIewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/MessageVIewController.swift
@@ -57,7 +57,7 @@ extension MessageViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        return "\(sortedMessages[section][0].message.sentDate.toString())에 수신하신 쪽지입니다"
+        return "\(sortedMessages[section][0].message.sentDate)에 수신하신 쪽지입니다"
     }
     
     
@@ -70,7 +70,7 @@ extension MessageViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 100
+        return 69
     }
 }
 

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/MessageVIewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/MessageVIewController.swift
@@ -49,8 +49,7 @@ class MessageViewController: BaseViewController {
 extension MessageViewController: UITableViewDataSource {
     
     func numberOfSections(in tableView: UITableView) -> Int {
-        print(sortedMessages.count)
-        sortedMessages.forEach{print($0)}
+        print("섹션갯수\(sortedMessages.count)")
         return sortedMessages.count
     }
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -58,14 +57,14 @@ extension MessageViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        return sortedMessages[section][0].message.sentDate.toString()
+        return "\(sortedMessages[section][0].message.sentDate.toString())에 수신하신 쪽지입니다"
     }
     
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: MessageTableViewCell.identifier, for: indexPath) as? MessageTableViewCell else { return UITableViewCell()}
     
-        cell.aa(section: indexPath.section, row: indexPath.row)
+        cell.configure(section: indexPath.section, row: indexPath.row)
         
         return cell
     }
@@ -104,6 +103,7 @@ func chunkedMessages(messages: MessagesWithChildName) -> [MessagesWithChildName]
         }
         currentDateMessages.append(message)
     }
+    messagesByDate.append(currentDateMessages)  //마지막 리스트도 추가하고 리턴해야함
     return messagesByDate
     
 }

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/MessageVIewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/MessageVIewController.swift
@@ -12,7 +12,6 @@ typealias MessagesWithChildName = [(childName: String, message: Message)]
 class MessageViewController: BaseViewController {
     
     // MARK: - Properties
-    let messagesWithChildName = mainTeacher.parentUsers.flatMap({$0.getMessagesWithChildName()})
     
     private let tableView: UITableView = {
         let tableView = UITableView(frame: .zero, style: .plain)
@@ -45,37 +44,28 @@ class MessageViewController: BaseViewController {
         self.navigationController?.navigationBar.tintColor = .black
         self.navigationController?.navigationBar.prefersLargeTitles = true
     }
-    
-    func chunkedMessages(_ messages: MessagesWithChildName) -> [MessagesWithChildName] {
-        var messagesByDate: [MessagesWithChildName] = []
-        var currentDateMessages: MessagesWithChildName = []
-        
-        for message in messagesWithChildName {
-            if let lastElement = currentDateMessages.last {
-                if lastElement.message.sentDate != message.message.sentDate {
-                    messagesByDate.append(currentDateMessages)
-                    currentDateMessages = []
-                }
-            }
-            currentDateMessages.append(message)
-        }
-        return messagesByDate
-        
-    }
-
 }
 
 extension MessageViewController: UITableViewDataSource {
+    
+    func numberOfSections(in tableView: UITableView) -> Int {
+        print(sortedMessages.count)
+        sortedMessages.forEach{print($0)}
+        return sortedMessages.count
+    }
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return messagesWithChildName.count
+        return sortedMessages[section].count
+    }
+    
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return sortedMessages[section][0].message.sentDate.toString()
     }
     
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: MessageTableViewCell.identifier, for: indexPath) as? MessageTableViewCell else { return UITableViewCell()}
-        
-        let messageInfo = messagesWithChildName[indexPath.row]
-        cell.configure(childName: messageInfo.childName, message: messageInfo.message)  
+    
+        cell.aa(section: indexPath.section, row: indexPath.row)
         
         return cell
     }
@@ -101,3 +91,19 @@ extension MessageViewController: UITableViewDelegate {
     }
 }
 
+func chunkedMessages(messages: MessagesWithChildName) -> [MessagesWithChildName] {
+    var messagesByDate: [MessagesWithChildName] = []
+    var currentDateMessages: MessagesWithChildName = []
+    
+    for message in messages {
+        if let lastElement = currentDateMessages.last {
+            if lastElement.message.sentDate != message.message.sentDate {
+                messagesByDate.append(currentDateMessages)
+                currentDateMessages = []
+            }
+        }
+        currentDateMessages.append(message)
+    }
+    return messagesByDate
+    
+}

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/MessageVIewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/MessageVIewController.swift
@@ -81,3 +81,28 @@ extension MessageViewController: UITableViewDelegate {
         present(alert, animated: true, completion: nil)
     }
 }
+
+//MARK: Chunk Logic Extension
+extension TeacherUser {
+    private var sortedMessage: [Message] {
+        return parentUsers.flatMap({$0.sendingMessages}).sorted(by: {$0.sentDate < $1.sentDate})
+    }
+    
+    var messagesByDate: [[Message]] {
+        var messagesByDate: [[Message]] = []
+        var currentDateMessages: [Message] = []
+        
+        for message in sortedMessage {
+            if let lastElement = currentDateMessages.last {
+                if lastElement.sentDate != message.sentDate {
+                    messagesByDate.append(currentDateMessages)
+                    currentDateMessages = []
+                }
+            }
+            
+            currentDateMessages.append(message)
+        }
+        
+        return messagesByDate
+    }
+}


### PR DESCRIPTION
## 🍏 관련 이슈
#56 

## 🍏 작업내용
타입이 namedTuple이들어있는 리스트라 계속 사용하기에는 가독성이 좋지 않아 typealias를 사용하였습니다
```swift
typealias MessagesWithChildName = [(childName: String, message: Message)]
```

아이이름과 메세지가 있는 튜플을 같은날짜끼리 하나의 리스트로 만들어 새로운 리스트에 넣어줍니다(2차원배열) 
```swift
var messagesWithChildName = mainTeacher.parentUsers.flatMap({$0.getMessagesWithChildName()})
var sortedMessages = chunkedMessages(messages: messagesWithChildName.sorted(by: {$0.message.sentDate < $1.message.sentDate}))
```

"chunked"는 알고리즘 방식중하나로 알고리즘패키지를 쓰면 편하게 사용이가능하나
패키지를 사용하기보다는 직접구현해도 될것같아 직접 구현해서 사용하게되었습니다
```swift
func chunkedMessages(messages: MessagesWithChildName) -> [MessagesWithChildName] {
    var messagesByDate: [MessagesWithChildName] = []
    var currentDateMessages: MessagesWithChildName = []
    
    for message in messages {
        if let lastElement = currentDateMessages.last {
            if lastElement.message.sentDate != message.message.sentDate {
                messagesByDate.append(currentDateMessages)
                currentDateMessages = []
            }
        }
        currentDateMessages.append(message)
    }
    messagesByDate.append(currentDateMessages)  //마지막 리스트도 추가하고 리턴해야함
    return messagesByDate
    
}
```
<img width="300" alt="스크린샷 2022-07-29 오전 2 33 58" src="https://user-images.githubusercontent.com/99013115/181601386-8d81a0a4-694a-4d74-9768-e5c75c71e0e3.png">



## 🍏 다음으로 진행될 작업
 - [ ] Hifi디자인 적용

## 🍏 주의사항
- **빈 폴더 있는지 확인하기!!**
- **파일,폴더 위치 및 이동 하지말기!!**
