### PR TITLE
[CHORE] 학부모 뷰 세부 UI 조정

### DIFF
--- a/Gajeongtongsin/Gajeongtongsin/Global/Extension/Date+Extension.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Global/Extension/Date+Extension.swift
@@ -10,13 +10,13 @@ import Foundation
 extension Date {
     func toString() -> String {
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "M월dd일"
+        dateFormatter.dateFormat = "M월d일"
         dateFormatter.timeZone = TimeZone(identifier: "ko_KR")
         return dateFormatter.string(from: self)
     }
     func toStringWithTime() -> String {
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "M월dd일 HH시mm분"
+        dateFormatter.dateFormat = "M월d일 HH시mm분"
         dateFormatter.timeZone = TimeZone(identifier: "ko_KR")
         return dateFormatter.string(from: self)
     }

--- a/Gajeongtongsin/Gajeongtongsin/Global/Extension/Date+Extension.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Global/Extension/Date+Extension.swift
@@ -10,7 +10,13 @@ import Foundation
 extension Date {
     func toString() -> String {
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "MM월dd일"
+        dateFormatter.dateFormat = "M월dd일"
+        dateFormatter.timeZone = TimeZone(identifier: "ko_KR")
+        return dateFormatter.string(from: self)
+    }
+    func toStringWithTime() -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "M월dd일 HH시mm분"
         dateFormatter.timeZone = TimeZone(identifier: "ko_KR")
         return dateFormatter.string(from: self)
     }

--- a/Gajeongtongsin/Gajeongtongsin/Global/UIComponent/PrimaryButton.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Global/UIComponent/PrimaryButton.swift
@@ -13,14 +13,9 @@ class PrimaryButton: UIButton {
     init(buttonTitle: String, buttonState: ButtonState) {
         super.init(frame: CGRect(x: 0, y: 0, width: 1000, height: 50))
         
-        switch buttonState {
-        case .normal:
-            self.setTitleColor(.white, for: .normal) //버튼 타이틀 색깔
-            self.backgroundColor = .Action      // 버튼 배경화면 색깔
-        case .disabled:
-            self.setTitleColor(.lightText, for: .normal) //버튼 타이틀 색깔
-            self.backgroundColor = .LightLine      // 버튼 배경화면 색깔
-        }
+        self.setTitle(buttonTitle, for: .normal)  // 버튼 타이틀
+        changeState(buttonState: buttonState)
+        render()
     }
     
     required init?(coder: NSCoder) {
@@ -30,11 +25,22 @@ class PrimaryButton: UIButton {
     // MARK: - Funcs
     func render() {
         self.titleLabel?.font = UIFont.systemFont(ofSize: 16, weight: .bold)
-        self.setTitle("PrimaryButton", for: .normal)  // 버튼 타이틀
         self.layer.cornerRadius = 3// 버튼 cornerRadius
-        
         self.translatesAutoresizingMaskIntoConstraints = false
         self.widthAnchor.constraint(equalToConstant: 358).isActive = true
         self.heightAnchor.constraint(equalToConstant: 50).isActive = true
+    }
+    
+    func changeState(buttonState: ButtonState) {
+        switch buttonState {
+        case .normal:
+            self.setTitleColor(.white, for: .normal) //버튼 타이틀 색깔
+            self.backgroundColor = .Action      // 버튼 배경화면 색깔
+            self.isUserInteractionEnabled = true // disabled 상태였던 버튼을 normal로 바꾸는 동시에 클릭 가능하게 변경
+        case .disabled:
+            self.setTitleColor(.lightText, for: .normal) //버튼 타이틀 색깔
+            self.backgroundColor = .LightLine      // 버튼 배경화면 색깔
+            self.isUserInteractionEnabled = false // disabled 상태에서는 클릭 불가
+        }
     }
 }

--- a/Gajeongtongsin/Gajeongtongsin/Global/UIComponent/SecondaryButton.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Global/UIComponent/SecondaryButton.swift
@@ -13,14 +13,9 @@ class SecondaryButton: UIButton {
     init(buttonTitle: String, buttonState: ButtonState) {
         super.init(frame: CGRect(x: 0, y: 0, width: 1000, height: 50))
         
-        switch buttonState {
-        case.normal:
-            self.setTitleColor(.white, for: .normal)
-            self.backgroundColor = .Action
-        case .disabled:
-            self.setTitleColor(.Confirm, for: .normal)
-            self.backgroundColor = .black
-        }
+        self.setTitle(buttonTitle, for: .normal)  // 버튼 타이틀
+        changeState(buttonState: buttonState)
+        render()
     }
     
     required init?(coder: NSCoder) {
@@ -31,12 +26,24 @@ class SecondaryButton: UIButton {
     // MARK: - Funcs
     func render() {
         self.titleLabel?.font = UIFont.systemFont(ofSize: 15, weight: .regular)
-        self.setTitle("SecondaryButton", for: .normal)
         self.layer.cornerRadius = 10
         
         self.translatesAutoresizingMaskIntoConstraints = false
         self.widthAnchor.constraint(equalToConstant: 100).isActive = true
         self.heightAnchor.constraint(equalToConstant: 30).isActive = true
+    }
+    
+    func changeState(buttonState: ButtonState) {
+        switch buttonState {
+        case .normal:
+            self.setTitleColor(.white, for: .normal) //버튼 타이틀 색깔
+            self.backgroundColor = .Action      // 버튼 배경화면 색깔
+            self.isUserInteractionEnabled = true // disabled 상태였던 버튼을 normal로 바꾸는 동시에 클릭 가능하게 변경
+        case .disabled:
+            self.setTitleColor(.Confirm, for: .normal) //버튼 타이틀 색깔
+            self.backgroundColor = .black      // 버튼 배경화면 색깔
+            self.isUserInteractionEnabled = false // disabled 상태에서는 클릭 불가
+        }
     }
     
 }

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ReservationDetailViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ReservationDetailViewController.swift
@@ -94,7 +94,7 @@ class ReservationDetailViewController: BaseViewController {
     }
     
     override func configUI() {
-        view.backgroundColor = .primaryBackground
+        view.backgroundColor = .Background
         navigationController?.navigationBar.tintColor = .black
     }
     

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ReservationViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ReservationViewController.swift
@@ -35,7 +35,7 @@ class ReservationViewController: BaseViewController {
     private let reserveButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(systemName: "calendar.badge.plus"), for: .normal)
-        button.setTitleColor(.black, for: .normal)
+        button.tintColor = .Action
         button.showsMenuAsPrimaryAction = true
         button.translatesAutoresizingMaskIntoConstraints = false
         return button

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/UrgentRequestViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/UrgentRequestViewController.swift
@@ -152,14 +152,9 @@ extension UrgentRequestViewController: UITextViewDelegate {
     
     //텍스트뷰 편집 종료 시 내용이 있으면 전송버튼 활성화, 내용이 없으면 플레이스홀더 원복시키고 전송버튼 비활성화 (내용 없이 날아가는 긴급요청 방지)
     func textViewDidEndEditing(_ textView: UITextView) {
-        if textView.text.isEmpty {
+        if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             textView.text = textPlaceHolder
             textView.textColor = .lightGray
-            submitBtn.setTitleColor(.black, for: .normal)
-            submitBtn.isUserInteractionEnabled = false
-        } else {
-            submitBtn.setTitleColor(.Action, for: .normal)
-            submitBtn.isUserInteractionEnabled = true
         }
     }
 
@@ -176,8 +171,11 @@ extension UrgentRequestViewController: UITextViewDelegate {
             submitBtn.setTitleColor(.black, for: .normal)
             submitBtn.isUserInteractionEnabled = false
         } else {
-            submitBtn.setTitleColor(.Action, for: .normal)
-            submitBtn.isUserInteractionEnabled = true
+            if !textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                submitBtn.setTitleColor(.Action, for: .normal)
+                submitBtn.isUserInteractionEnabled = true
+            }
+           
         }
 
     }

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/UrgentRequestViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/UrgentRequestViewController.swift
@@ -22,7 +22,7 @@ class UrgentRequestViewController: BaseViewController {
     private let submitBtn: UIButton = {
         let label = UIButton()
         label.setTitle("신청", for: .normal)
-        label.setTitleColor(UIColor.Action, for: .normal)
+        label.setTitleColor(UIColor.black, for: .normal)
         label.isUserInteractionEnabled = false
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
@@ -150,14 +150,15 @@ extension UrgentRequestViewController: UITextViewDelegate {
         }
     }
     
-    
     //텍스트뷰 편집 종료 시 내용이 있으면 전송버튼 활성화, 내용이 없으면 플레이스홀더 원복시키고 전송버튼 비활성화 (내용 없이 날아가는 긴급요청 방지)
     func textViewDidEndEditing(_ textView: UITextView) {
-        if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        if textView.text.isEmpty {
             textView.text = textPlaceHolder
             textView.textColor = .lightGray
+            submitBtn.setTitleColor(.black, for: .normal)
             submitBtn.isUserInteractionEnabled = false
         } else {
+            submitBtn.setTitleColor(.Action, for: .normal)
             submitBtn.isUserInteractionEnabled = true
         }
     }
@@ -167,6 +168,17 @@ extension UrgentRequestViewController: UITextViewDelegate {
         if reasonText.text.count > 300 {
             reasonText.deleteBackward()
         }
-    }
+        
+        if textView.text.isEmpty {
+            textView.text = textPlaceHolder
+            textView.textColor = .lightGray
+            textView.resignFirstResponder()
+            submitBtn.setTitleColor(.black, for: .normal)
+            submitBtn.isUserInteractionEnabled = false
+        } else {
+            submitBtn.setTitleColor(.Action, for: .normal)
+            submitBtn.isUserInteractionEnabled = true
+        }
 
+    }
 }

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/UrgentRequestViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/UrgentRequestViewController.swift
@@ -92,7 +92,7 @@ class UrgentRequestViewController: BaseViewController {
     
     //신청, 취소 버튼
     override func configUI() {
-        view.backgroundColor = .primaryBackground
+        view.backgroundColor = .Background
         cancelBtn.addTarget(self, action: #selector(cancel), for: .touchUpInside)
         submitBtn.addTarget(self, action: #selector(submit), for: .touchUpInside)
 

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/UrgentRequestViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/UrgentRequestViewController.swift
@@ -15,14 +15,14 @@ class UrgentRequestViewController: BaseViewController {
     private let cancelBtn: UIButton = {
         let label = UIButton()
         label.setTitle("취소", for: .normal)
-        label.setTitleColor(UIColor.black, for: .normal)
+        label.setTitleColor(UIColor.Action, for: .normal)
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
     private let submitBtn: UIButton = {
         let label = UIButton()
         label.setTitle("신청", for: .normal)
-        label.setTitleColor(UIColor.black, for: .normal)
+        label.setTitleColor(UIColor.Action, for: .normal)
         label.isUserInteractionEnabled = false
         label.translatesAutoresizingMaskIntoConstraints = false
         return label

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SendingViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SendingViewController.swift
@@ -87,8 +87,6 @@ class SendingViewController: BaseViewController {
     
     
     //사유 입력하는 Text Field View
-    //TODO: -
-    //Text Field 내 여백 padding 값 조절, 글자수 제한, 박스 외부 클릭했을 때 커서와 키보드 사라지게 등등
     private let textFieldForReason: UITextField = {
         let textF = UITextField()
         let leftMargin = UIView(frame: CGRect(x: 0, y: 0, width: 5, height: textF.frame.height))
@@ -252,14 +250,6 @@ extension SendingViewController: UITextFieldDelegate {
         }
 
         return true
-    }
-    
-    func textFieldDidEndEditing(_ textField: UITextField) {
-        if textField.text?.trimmingCharacters(in: .whitespacesAndNewlines) != "" {
-            sendButton.changeState(buttonState: .normal)
-        } else {
-            sendButton.changeState(buttonState: .disabled)
-        }
     }
     
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SendingViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Sending/SendingViewController.swift
@@ -52,7 +52,7 @@ class SendingViewController: BaseViewController {
     //메시지 버튼 내 text와 image 간격 조정, 사이 구분선 삽입
     private let messageTypeButton: UIButton = {
         let button = UIButton()
-        button.setTitle("용건 선택", for: .normal)
+        button.setTitle("용건 선택   ", for: .normal)
         button.setTitleColor(UIColor.black, for: .normal)
         button.backgroundColor = .secondarySystemFill
         button.titleLabel?.font = UIFont.systemFont(ofSize: 17, weight: .medium)
@@ -88,7 +88,8 @@ class SendingViewController: BaseViewController {
         let picker = UIDatePicker()
         picker.isHidden = true
         picker.preferredDatePickerStyle = .compact
-        picker.locale = Locale(identifier: "ko-KR")
+        picker.locale = Locale(identifier: "ko_KR")
+        picker.timeZone = TimeZone(identifier: "ko_KR")
         picker.minuteInterval = 30
         picker.translatesAutoresizingMaskIntoConstraints = false
         return picker
@@ -210,21 +211,26 @@ class SendingViewController: BaseViewController {
         return msgType
     }
     
+    func dateType() -> String {
+        let dateType = messageTypeButton.currentTitle == "결석" ? "\(datePicker.date.toString())" : "\(datePicker.date.toStringWithTime())"
+        return dateType
+    }
+    
     @objc func sendAlert() {
-        let alert = UIAlertController(title: "긴급 상담 요청", message: "정말 급한 상담인지 다시 한 번 생각해주세요", preferredStyle: .alert)
+        let alert = UIAlertController(title: "쪽지를 전송하시겠습니까?", message: nil, preferredStyle: .alert)
         let cancelAction = UIAlertAction(title: "취소", style: .cancel)
-        let okayAction = UIAlertAction(title: "신청", style: .default) { _ in
+        let okayAction = UIAlertAction(title: "전송", style: .default) { _ in
             self.sendMessage()
         }
         alert.addAction(cancelAction)
         alert.addAction(okayAction)
         self.present(alert, animated: true)
     }
-  
+    
     func sendMessage() {
         let newMsg = Message(type: msgType(),
                              sentDate: "2022-03-21",
-                             expectedDate: "\(datePicker.date)",
+                             expectedDate: dateType(),
                              content: textFieldForReason.text ?? "",
                              isCompleted: false)
         
@@ -234,6 +240,7 @@ class SendingViewController: BaseViewController {
         delegate?.reloadTable()
         navigationController?.popViewController(animated: true)
     }
+
 }
 
 //MARK: - Extensions
@@ -251,4 +258,5 @@ extension SendingViewController: UITextFieldDelegate {
         textField.resignFirstResponder()
         return true
     }
+    
 }

--- a/Gajeongtongsin/Gajeongtongsin/Screens/TabBar/TabBarViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/TabBar/TabBarViewController.swift
@@ -60,7 +60,7 @@ class TabBarViewController: UITabBarController {
                                       image: TabPage.profile.getTabBarIcon(),
                                        tag: 2)
 
-        tabBar.tintColor = .systemBlue
+        tabBar.tintColor = .Action
         tabBar.backgroundColor = .white
         tabBar.layer.borderWidth = 2
         tabBar.layer.borderColor = UIColor.LightLine.cgColor

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/NotificationViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Receiving/NotificationViewController.swift
@@ -11,7 +11,7 @@ let sections = ["긴급알림", "일반알림"]
 class NotificationViewController: BaseViewController {
     
     // MARK: - Properties
-    var emergancy: [Notification] {
+    var emergency: [Notification] {
         mainTeacher.notificationList.filter { $0.type == .emergency }
     }
     
@@ -108,7 +108,7 @@ extension NotificationViewController: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         if section == 0 {
-            return emergancy.count
+            return emergency.count
         }
         return normal.count
     }
@@ -116,7 +116,7 @@ extension NotificationViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: NotificationTableViewCell.identifier, for: indexPath) as? NotificationTableViewCell else { return UITableViewCell()}
         if indexPath.section == 0 {
-            cell.configure(notification: emergancy[indexPath.row])
+            cell.configure(notification: emergency[indexPath.row])
 
             cell.backgroundColor = UIColor.Confirm
 
@@ -136,7 +136,7 @@ extension NotificationViewController: UITableViewDataSource {
 
 extension NotificationViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let currentMessage = emergancy[indexPath.row]
+        let currentMessage = emergency[indexPath.row]
         tableView.deselectRow(at: indexPath, animated: true)
         if indexPath.section == 0 {
             let alret = UIAlertController(title: "\(currentMessage.childName) 긴급상담용건", message: currentMessage.content, preferredStyle: .alert)


### PR DESCRIPTION
## 🍏 관련 이슈
#44 

## 🍏 작업내용
- 긴급상담 모달 (내용 없이 신청 불가)

<img width="388" alt="image" src="https://user-images.githubusercontent.com/103012800/182080177-487f9e9d-0c63-42f9-8a14-926ef223f39a.png">

- 텍스트필드 오류 수정 (내용 없이 전송 불가)
<img width="382" alt="image" src="https://user-images.githubusercontent.com/103012800/182080269-72617dc4-be20-40d5-b2ec-05a15dcae730.png">


- Date Formatter 수정 (날짜뿐만 아니라 시간도 보낼 수 있도록, 01월 01일 대신 1월 1일로 표기 등)
```
        dateFormatter.dateFormat = "MM월dd일"
        dateFormatter.dateFormat = "M월d일"
```

`let dateType = messageTypeButton.currentTitle == "결석" ? "\(datePicker.date.toString())" : "\(datePicker.date.toStringWithTime())"`


- 공용 버튼 컴포넌트 바로 가져다 쓸 수 있게 수정 (타이틀 속성이 바로 버튼 타이틀로 바뀌도록, 버튼 state를 프로퍼티 종속된 함수 통해 변경)

```
func changeState(buttonState: ButtonState) {
        switch buttonState {
        case .normal:
            self.setTitleColor(.white, for: .normal) //버튼 타이틀 색깔
            self.backgroundColor = .Action      // 버튼 배경화면 색깔
            self.isUserInteractionEnabled = true // disabled 상태였던 버튼을 normal로 바꾸는 동시에 클릭 가능하게 변경
        case .disabled:
            self.setTitleColor(.lightText, for: .normal) //버튼 타이틀 색깔
            self.backgroundColor = .LightLine      // 버튼 배경화면 색깔
            self.isUserInteractionEnabled = false // disabled 상태에서는 클릭 불가
        }
    }
```

- Emergancy 오타 수정

```
    var emergancy: [Notification] {
    var emergency: [Notification] {
```

## 🍏 다음으로 진행될 작업
 - [ ] Custom Nav Bar 일괄 적용
 - [ ] 버튼 컴포넌트, 인디케이터 디자인 일괄 적용

## 🍏 주의사항
- **빈 폴더 있는지 확인하기!!**
- **파일,폴더 위치 및 이동 하지말기!!**
