### PR TITLE
[FIX]교사 캘린더뷰의 학부모 컬렉션뷰 예약확정시 밀림 버그 해결

### DIFF
--- a/Gajeongtongsin/Gajeongtongsin/Global/Literal/Constants.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Global/Literal/Constants.swift
@@ -91,7 +91,7 @@ struct Constants {
         formatter.dateFormat = "d-EEE"
         
         for day in 0..<5 {
-            let dayAdded = (86400 * (2+day-todayOfTheWeek))
+            let dayAdded = (86400 * (2+day-todayOfTheWeek+7))
             let oneDayString = formatter.string(from: Date(timeIntervalSinceNow: TimeInterval(dayAdded))).components(separatedBy: "-")
             oneDayString.forEach {
                 let label = UILabel()

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Consultation/ConsultationViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Teacher/Consultation/ConsultationViewController.swift
@@ -215,22 +215,22 @@ class ConsultationViewController: BaseViewController {
     //미확정 예약 데이터를 인덱스로 만들어주는 함수
     func submittedData() -> [TeacherCalenderData] {
         var calenderIndex: [Int] = []
+        var submittedData:[TeacherCalenderData] = []
         
         for parentsIndex in 0 ..< allSchedules.count {
             calenderIndex = []
             guard let parentShedules = allSchedules[parentsIndex].schedule else { return []}
-            for scheduleIndex in
-                    0 ..< parentShedules[0].scheduleList.count {
-                
-                if parentShedules[0].scheduleList[scheduleIndex].isReserved == false {
+            if parentShedules[0].scheduleList[0].isReserved == false {
+                for scheduleIndex in 0 ..< parentShedules[0].scheduleList.count {
                     let rowIndex = timeStringToIndex(parentIndex: parentsIndex)[scheduleIndex] * weekDays
                     let columnIndex = dateStringToIndex(parentsIndex: parentsIndex)[scheduleIndex]
                     calenderIndex.append(rowIndex + columnIndex)
                 }
+                submittedData.append(calenderData[parentsIndex])
+                submittedData[submittedData.count-1].calenderIndex = calenderIndex
             }
-            calenderData[parentsIndex].calenderIndex = calenderIndex
         }
-        return calenderData
+        return submittedData
     }
     
     //선택한 학부모의 신청 요일(날자)를 정수(인덱스) 리스트로 반환해주는 함수


### PR DESCRIPTION
## 🍏 관련 이슈
<!-- 해당 PR과 관련된 이슈를 링크해주세요. -->

## 🍏 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
앞쪽 인덱스에 해당하는 카드를 예약확정한 경우, 해당 카드는 사라지고 이후 카드들의 예약 데이터들이 한칸씩 밀려서 새로 저장되는 버그가 있었다.
컬렉션뷰 생성에 관여하는 calenderData 함수를 수정함으로써 해결했다.

## 🍏 다음으로 진행될 작업
 - [ ] 파이어베이스 연결

## 🍏 주의사항
- **빈 폴더 있는지 확인하기!!**
- **파일,폴더 위치 및 이동 하지말기!!**
