### PR TITLE
[FIX] 캘린더뷰 요일 개별 인덱싱 로직 수정 (교사, 학부모뷰 모두)

### DIFF
--- a/Gajeongtongsin/Gajeongtongsin.xcodeproj/project.pbxproj
+++ b/Gajeongtongsin/Gajeongtongsin.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		04610D952886A28C00CCCB2D /* CalenderViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04610D942886A28C00CCCB2D /* CalenderViewCell.swift */; };
 		046BFDF62890DD8000591577 /* CalenderTabelViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 046BFDF52890DD8000591577 /* CalenderTabelViewCell.swift */; };
 		04797679288E7855009C0826 /* TeacherCalenderData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04797678288E7855009C0826 /* TeacherCalenderData.swift */; };
+		04A0370128BC9D87007A73C8 /* CalenderSlotData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04A0370028BC9D87007A73C8 /* CalenderSlotData.swift */; };
+		04A0370328BC9EDC007A73C8 /* CalenderSlotMockData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04A0370228BC9EDC007A73C8 /* CalenderSlotMockData.swift */; };
 		35171CFE28828C930059F297 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35171CFD28828C930059F297 /* AppDelegate.swift */; };
 		35171D0028828C930059F297 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35171CFF28828C930059F297 /* SceneDelegate.swift */; };
 		35171D0728828C930059F297 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 35171D0628828C930059F297 /* Assets.xcassets */; };
@@ -79,6 +81,8 @@
 		04610D942886A28C00CCCB2D /* CalenderViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalenderViewCell.swift; sourceTree = "<group>"; };
 		046BFDF52890DD8000591577 /* CalenderTabelViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalenderTabelViewCell.swift; sourceTree = "<group>"; };
 		04797678288E7855009C0826 /* TeacherCalenderData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeacherCalenderData.swift; sourceTree = "<group>"; };
+		04A0370028BC9D87007A73C8 /* CalenderSlotData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalenderSlotData.swift; sourceTree = "<group>"; };
+		04A0370228BC9EDC007A73C8 /* CalenderSlotMockData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalenderSlotMockData.swift; sourceTree = "<group>"; };
 		35171CFA28828C930059F297 /* Gajeongtongsin.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Gajeongtongsin.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		35171CFD28828C930059F297 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		35171CFF28828C930059F297 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -180,6 +184,7 @@
 			isa = PBXGroup;
 			children = (
 				04797678288E7855009C0826 /* TeacherCalenderData.swift */,
+				04A0370028BC9D87007A73C8 /* CalenderSlotData.swift */,
 				C0DFFBFC2885DC86009A1563 /* ParentUser.swift */,
 				C0DFFC022885DE32009A1563 /* Message.swift */,
 				C0DFFC042885DF05009A1563 /* Schedule.swift */,
@@ -201,6 +206,7 @@
 				35171D1628828EE60059F297 /* Supports */,
 				35171D1528828E990059F297 /* Resources */,
 				35171D1428828E950059F297 /* Service */,
+				04A0370228BC9EDC007A73C8 /* CalenderSlotMockData.swift */,
 			);
 			path = Global;
 			sourceTree = "<group>";
@@ -569,6 +575,7 @@
 				C0DFFC072885DFEB009A1563 /* ScheduleInfo.swift in Sources */,
 				3595839E28829D80002B6873 /* ProfileViewController.swift in Sources */,
 				8C7C924E2892D75E00C878AF /* UrgentRequestViewController.swift in Sources */,
+				04A0370128BC9D87007A73C8 /* CalenderSlotData.swift in Sources */,
 				C054017D288D04F6002BF33B /* NotificationViewController.swift in Sources */,
 				046BFDF62890DD8000591577 /* CalenderTabelViewCell.swift in Sources */,
 				C056F6AD288B0A770070EED5 /* MessageVIewController.swift in Sources */,
@@ -578,6 +585,7 @@
 				040612A628941F2800791763 /* ParentsCollcetionViewCellDelegate.swift in Sources */,
 				C01FA468289406C700A1E4DB /* String+Extension.swift in Sources */,
 				359583A228829D93002B6873 /* TestK.swift in Sources */,
+				04A0370328BC9EDC007A73C8 /* CalenderSlotMockData.swift in Sources */,
 				8C3DD251288A63CF00A3E9C6 /* SentMessageListViewController.swift in Sources */,
 				C0B4A4322890E8B9001DC86C /* CutomNavigationBarDelegate.swift in Sources */,
 				356B77E5289457A3001D2F6C /* ParentRegistrationViewController.swift in Sources */,

--- a/Gajeongtongsin/Gajeongtongsin/Global/CalenderSlotMockData.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Global/CalenderSlotMockData.swift
@@ -1,0 +1,24 @@
+//
+//  CalenderSlotMockData.swift
+//  Gajeongtongsin
+//
+//  Created by Beone on 2022/08/29.
+//
+
+import Foundation
+
+func calenderSlotDataMaker() -> CalenderSlotData {
+    var blockedSlot: [[Bool]] =  Array(repeating: Array(repeating: false, count: 18), count:weekDays)
+    for section in 0..<weekDays {
+        for index in 0..<3 {
+            blockedSlot[section][index].toggle()
+        }
+        for index in 12..<18 {
+            blockedSlot[section][index].toggle()
+        }
+    }
+//    CalenderSlotData(blockedSlot: [], addedSlot: [])
+    return CalenderSlotData(blockedSlot: blockedSlot)
+}
+
+var calenderSlotData: CalenderSlotData = calenderSlotDataMaker()

--- a/Gajeongtongsin/Gajeongtongsin/Models/CalenderSlotData.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Models/CalenderSlotData.swift
@@ -1,0 +1,14 @@
+//
+//  CalenderSlotData.swift
+//  Gajeongtongsin
+//
+//  Created by Beone on 2022/08/29.
+//
+
+import Foundation
+
+struct CalenderSlotData {
+//    var blockedSlot: [[Int]]
+//    var addedSlot: [[Int]]
+    var blockedSlot: [[Bool]]
+}

--- a/Gajeongtongsin/Gajeongtongsin/Models/TeacherCalenderData.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Models/TeacherCalenderData.swift
@@ -11,6 +11,6 @@ import UIKit
 struct TeacherCalenderData {
     var parentsIndex: Int
 //    var calenderIndex: calenderIndex
-    var calenderIndex: [Int]
+    var calenderIndex: [[Int]]
     var cellColor: UIColor
 }

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ParentsCalenderViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ParentsCalenderViewController.swift
@@ -40,7 +40,7 @@ class ParentsCalenderViewController: BaseViewController {
     }
     
     //모든 예약일정이 저장되는 리스트
-    private lazy var submittedData: [Int] = []
+    private lazy var submittedData: [[Int]] = []
 
     
     // 캘린더뷰
@@ -173,17 +173,17 @@ class ParentsCalenderViewController: BaseViewController {
     }
     
     //모든 예약일정을 인덱스로 저장해주는 함수, 교사뷰의 동명 함수와 다름!!
-    func submittedDataMaker() -> [Int] {
-    var calenderData: [Int] = []
+    func submittedDataMaker() -> [[Int]] {
+    var calenderData: [[Int]] = []
         
         for parentsIndex in 0 ..< allSchedules.count {
             guard let parentShedules = allSchedules[parentsIndex].schedule else { return []}
 
             for scheduleIndex in 0 ..< parentShedules[0].scheduleList.count {
                 
-                    let rowIndex = timeStringToIndex(parentIndex: parentsIndex)[scheduleIndex] * weekDays
+                    let rowIndex = timeStringToIndex(parentIndex: parentsIndex)[scheduleIndex]
                     let columnIndex = dateStringToIndex(parentsIndex: parentsIndex)[scheduleIndex]
-                    calenderData.append(rowIndex + columnIndex)
+                    calenderData.append([columnIndex, rowIndex])
             }
             
         }
@@ -348,7 +348,7 @@ extension ParentsCalenderViewController: UICollectionViewDelegate{
                return UICollectionViewCell()
            }
 //        cell.backgroundColor = submittedData.conta .white
-            if submittedData.contains(indexPath.item) {
+        if submittedData.contains([indexPath.section, indexPath.item]) {
                 cell.backgroundColor = .lightGray
             }
         
@@ -362,7 +362,7 @@ extension ParentsCalenderViewController: UICollectionViewDelegate{
         //선택한 슬롯 개수 카운터
         let truCnt = choicedCells.flatMap{$0}.filter({$0 == true}).count
         
-        if submittedData.contains(indexPath.item) != true {
+        if submittedData.contains([indexPath.section, indexPath.item]) != true {
             //갯수 3개로 제한 및 선택 토글  +섹션 나눠서 인덱싱 편하게 하기?
             if truCnt<3 && !choicedCells[indexPath.section][indexPath.item] {
                 choicedCells[indexPath.section][indexPath.item].toggle()

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ParentsCalenderViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Parent/Reservation/ParentsCalenderViewController.swift
@@ -190,18 +190,6 @@ class ParentsCalenderViewController: BaseViewController {
         return calenderData
     }
     
-//    func dateIndexToString(index: Int) -> String {
-//        let formatter = DateFormatter()
-//        formatter.dateFormat = "M월dd일"
-//        formatter.timeZone = TimeZone(identifier: "ko_KR")
-//        let daysAfterToday = (7+(index%weekDays+2)-todayOfTheWeek) //+2는 dateFormat 보정(월요일이 2), +7은 다음주 캘린더가 표시되도록
-//        let consultingDateDate = Date(timeIntervalSinceNow: TimeInterval((secondsInDay * daysAfterToday)))
-//
-//        consultingDateList = formatter.string(from: consultingDateDate) //Date -> [String]
-//        consultingDate = consultingDateList //[String] -> String
-//        return consultingDate
-//    }
-    
     func dateIndexToString(index: Int) -> String {
         return nextWeek[index]
     }
@@ -351,6 +339,9 @@ extension ParentsCalenderViewController: UICollectionViewDelegate{
         if submittedData.contains([indexPath.section, indexPath.item]) {
                 cell.backgroundColor = .lightGray
             }
+        if calenderSlotData.blockedSlot[indexPath.section][indexPath.item] {
+            cell.backgroundColor = .Background
+        }
         
         return cell
     }
@@ -362,9 +353,9 @@ extension ParentsCalenderViewController: UICollectionViewDelegate{
         //선택한 슬롯 개수 카운터
         let truCnt = choicedCells.flatMap{$0}.filter({$0 == true}).count
         
-        if submittedData.contains([indexPath.section, indexPath.item]) != true {
+        if !submittedData.contains([indexPath.section, indexPath.item]) && calenderSlotData.blockedSlot[indexPath.section][indexPath.item] {
             //갯수 3개로 제한 및 선택 토글  +섹션 나눠서 인덱싱 편하게 하기?
-            if truCnt<3 && !choicedCells[indexPath.section][indexPath.item] {
+            if truCnt<3 && !choicedCells[indexPath.section][indexPath.item]{
                 choicedCells[indexPath.section][indexPath.item].toggle()
                 cell?.backgroundColor = .Action
             }else if choicedCells[indexPath.section][indexPath.item]{

--- a/Gajeongtongsin/Gajeongtongsin/Screens/Profile/ProfileViewController.swift
+++ b/Gajeongtongsin/Gajeongtongsin/Screens/Profile/ProfileViewController.swift
@@ -5,35 +5,350 @@
 //  Created by DaeSeong on 2022/07/16.
 //
 
+//import UIKit
+//
+//class ProfileViewController: BaseViewController {
+//
+////    private let textLabel: UILabel = {
+////        let label = UILabel()
+////        label.text = "프로필 화면 준비중입니다 😎\(UserDefaults.standard.string(forKey: "TeacherUser") ?? "")"
+////        label.font = UIFont.systemFont(ofSize: 20)
+////        label.textColor = .black
+////        label.translatesAutoresizingMaskIntoConstraints = false
+////        return label
+////    }()
+//
+//    override func viewDidLoad() {
+//        super.viewDidLoad()
+//    }
+//
+//    override func render() {
+////        view.addSubview(textLabel)
+////        textLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+////        textLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
+//
+//
+//    }
+//
+//    override func configUI() {
+//        view.backgroundColor = .Background
+//    }
+//
+//
+//
+//}
+
+//
+//  ReservationViewController.swift
+//  Gajeongtongsin
+//
+//  Created by DaeSeong on 2022/07/16.
+//
+
 import UIKit
 
 class ProfileViewController: BaseViewController {
+    
+    //MARK: - Properties
+    private var choicedCells: [[Bool]] = Array(repeating: Array(repeating: false, count: 18), count:5) //복수선택 및 선택취소를 위한 array
+//    private var choicedCells: [Bool] = Array(repeating: false, count:6) //복수선택 및 선택취소를 위한 array
+    private var submitIndexList: [[Int]] = [[]] //신청버튼 클릭 후 신청내역 인덱스가 저장되는 리스트
+//    private var blockedScheduleList: [ScheduleInfo] = []
+    private var blockedSlotList: [[Int]] = []
+    private var subDate: [String] = []
+//    private var consultingDateDate: Date
+    private var consultingDateList: String = ""
+    private var consultingDate: String = "" //consultingDateDate -> consultingDateList -> consultingDate 순으로 탑다운
+    private var startTime: String = ""
+    
+    private var allSchedules: [(name: String, schedule: [Schedule]?)] = []
+    
+    //다음 일주일의 날짜 리스트를 저장하는 연산 프로퍼티, 아래의 dayIndex 함수에 사용함
+    //TODO: 교사 캘린더뷰에서 같이 쓰는 상수이므로 공용화시킬 수 있음
+    var nextWeek: [String] {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "M월dd일"
+        formatter.timeZone = TimeZone(identifier: "ko_KR")
+        var nextWeek = [String]()
+         
+        for dayCount in 0..<weekDays {
+//            let dayAdded = (86400 * (2+dayCount-todayOfTheWeek+7))
+            let dayAdded = (86400 * (2+dayCount-todayOfTheWeek + 7))
+            let oneDayString = formatter.string(from: Date(timeIntervalSinceNow: TimeInterval(dayAdded)))
+            nextWeek.append(oneDayString)
+        }
+        return nextWeek
+    }
+    
+    //모든 예약일정이 저장되는 리스트
+    private lazy var submittedData: [[Int]] = []
 
-    private let textLabel: UILabel = {
-        let label = UILabel()
-        label.text = "프로필 화면 준비중입니다 😎\(UserDefaults.standard.string(forKey: "TeacherUser") ?? "")"
-        label.font = UIFont.systemFont(ofSize: 20)
-        label.textColor = .black
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
+    
+    // 캘린더뷰
+    private let calenderView:  UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .horizontal
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView.register(CalenderViewCell.self, forCellWithReuseIdentifier: CalenderViewCell.identifier)
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        return collectionView
+    }()
+
+    
+    // 확인 버튼
+    
+    private let submitBtn: UIButton = {
+        let button = UIButton()
+        button.setTitle("확인", for: .normal)
+        button.setTitleColor(UIColor.lightGray, for: .normal)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
     }()
     
+    //캘린더 시간 레이블
+    lazy private var hourLabel: [UILabel] = Constants.hourLabelMaker()
+    
+    //캘린더 날자 레이블
+    lazy private var dateLabel: [[UILabel]] = Constants.dateLabelMaker()
+    
+    //MARK: - View Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        calenderView.delegate = self
+        calenderView.dataSource = self
+        
+        submitBtn.addTarget(self, action: #selector(onTapButton), for: .touchUpInside)
+
+        
+        FirebaseManager.shared.fetchParentsReservations { [weak self] schedules in
+            if let schedules = schedules {
+                self?.allSchedules = []
+                self?.allSchedules = self!.scheduledParentsListConVerter(schedules)
+                self?.submittedData = self!.submittedDataMaker()
+                self?.calenderView.reloadData()
+            }
+        }
     }
+    
+    func viewDidAppear() {
+        calenderView.reloadData()
+    }
+        
+    //MARK: - Funcs
+
+    
+    func scheduledParentsListConVerter(_ allSchedules: [String:[Schedule]]) -> [(String, [Schedule]?)] {
+        var scheduledParentsList: [(String, [Schedule]?)] = []
+        for key in allSchedules.keys {
+                scheduledParentsList.append((key,allSchedules[key]))
+        }
+        return scheduledParentsList
+    }
+
+//선택한 학부모의 신청 요일(날자)를 정수(인덱스) 리스트로 반환해주는 함수
+    //TODO: 파베 연결전 교사뷰의 동명 함수와 동일함, 파베 연결된 함수로 공용화
+    func dateStringToIndex(parentsIndex: Int) -> [Int] {
+        var dateString: [String] = []
+        var dateIndex: [Int] = []
+        guard let parentSchedules = allSchedules[parentsIndex].schedule else { return []}
+        parentSchedules[0].scheduleList.forEach{
+            dateString.append($0.consultingDate)
+        }
+        for day in 0..<dateString.count { //String을 Index로 바꿔줌
+            for nextWeekDay in 0..<nextWeek.count {
+                if dateString[day] == nextWeek[nextWeekDay] {
+                    dateIndex.append(nextWeekDay)
+                }
+            }
+        }
+        return dateIndex
+    }
+    
+    //선택한 학부모의 신청 시간을 정수(인덱스) 리스트로 반환해주는 함수
+    //TODO: 파베 연결전 교사뷰의 동명 함수와 동일함, 파베 연결된 함수로 공용화
+    func timeStringToIndex(parentIndex: Int) -> [Int] {
+        var startTime:[Int] = []
+        guard let parentSchedules = allSchedules[parentIndex].schedule else { return []}
+        parentSchedules[0].scheduleList.forEach{
+            let timeList = $0.startTime.components(separatedBy: "시")  //[14, 00], [14, 30], [15, 00], ...
+            let hour = Int(timeList[0])!-14 // 14, 14, 15, 15, 16, 16 ... -> 0, 0, 1, 1, 2, 2 ...
+            let minute = Int(timeList[1].replacingOccurrences(of: "분", with: ""))!/30 // 00, 30, 00, 30 ... -> 0, 1, 0, 1, ...
+            startTime.append(hour*2 + minute)
+        }
+        
+        return startTime
+    }
+    
+    //모든 예약일정을 인덱스로 저장해주는 함수, 교사뷰의 동명 함수와 다름!!
+    func submittedDataMaker() -> [[Int]] {
+    var calenderData: [[Int]] = []
+        
+        for parentsIndex in 0 ..< allSchedules.count {
+            guard let parentShedules = allSchedules[parentsIndex].schedule else { return []}
+
+            for scheduleIndex in 0 ..< parentShedules[0].scheduleList.count {
+                
+                    let rowIndex = timeStringToIndex(parentIndex: parentsIndex)[scheduleIndex]
+                    let columnIndex = dateStringToIndex(parentsIndex: parentsIndex)[scheduleIndex]
+                    calenderData.append([columnIndex, rowIndex])
+            }
+            
+        }
+        return calenderData
+    }
+    
+    
+    func dateIndexToString(index: Int) -> String {
+        return nextWeek[index]
+    }
+    
+    func timeIndexToString(index: Int) -> String {
+        let rowInCalender = index
+        let hour = String(14 + (rowInCalender)/2) //14시 + @
+        let minute: String = (rowInCalender) % 2 == 0 ? "00" : "30" //짝수줄은 정각, 홀수줄은 30분
+        startTime = hour+"시"+minute+"분"
+        
+        return startTime
+    }
+    
+    //신청하기 누르면 리로드 & 신청요일, 시간 mackdata에 추가 / print
+    @objc func onTapButton() {
+        
+//        blockedScheduleList = []
+//        blockedSlotList = []
+        for section in 0..<choicedCells.count {
+            let blockedSlotInSection = choicedCells[section].enumerated().compactMap { (idx, element) in element ? idx : nil }
+//            submitIndexList.append(blockedSlotInSection)
+
+            for index in blockedSlotInSection {
+                calenderSlotData.blockedSlot[section][index].toggle()
+            }
+        }
+//        choicedCells.ForEach {
+//            if calenderSlotData.blockedSlot.contains(choicedCells) {
+//                calenderSlotData.blockedSlot.remove(at: calenderSlotData.blockedSlot.first(choicedCells))
+//            }
+//        }
+        
+        print(calenderSlotData)
+        choicedCells = Array(repeating: Array(repeating: false, count: 18), count:5)
+        calenderView.reloadData()
+    }
+    let calenderTopPadding = CGFloat(140.0)
+    let calenderSidePadding = [CGFloat(50.0),CGFloat(20.0)]
+    let calenderHeigit = CGFloat(550.0)
     
     override func render() {
-        view.addSubview(textLabel)
-        textLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
-        textLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
 
+        view.addSubview(calenderView)
 
+        calenderView.topAnchor.constraint(equalTo: view.topAnchor, constant: calenderTopPadding).isActive = true
+        calenderView.heightAnchor.constraint(equalToConstant: calenderHeigit).isActive = true
+        calenderView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: calenderSidePadding[0]).isActive = true
+        calenderView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -calenderSidePadding[1]).isActive = true
+
+        view.addSubview(submitBtn)
+        submitBtn.topAnchor.constraint(equalTo: calenderView.bottomAnchor, constant: 20).isActive = true
+        submitBtn.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -30).isActive = true
+        
+        
+        for index in 0..<hourLabel.count {
+            view.addSubview(hourLabel[index])
+            hourLabel[index].centerYAnchor.constraint(equalTo: calenderView.topAnchor, constant: CGFloat(index*100)).isActive = true
+            hourLabel[index].leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20).isActive = true
+        }
+        
+        let interval = CGFloat((UIScreen.main.bounds.width-(calenderSidePadding[0]+calenderSidePadding[1]))/5)
+        
+        for index in 0..<dateLabel.count {
+            view.addSubview(dateLabel[index][0])
+            dateLabel[index][0].topAnchor.constraint(equalTo: calenderView.topAnchor, constant: -70).isActive = true
+            dateLabel[index][0].centerXAnchor.constraint(equalTo: calenderView.leadingAnchor, constant: CGFloat(index)*interval+interval/2).isActive = true
+            
+            view.addSubview(dateLabel[index][1])
+            dateLabel[index][1].topAnchor.constraint(equalTo: calenderView.topAnchor, constant: -40).isActive = true
+            dateLabel[index][1].centerXAnchor.constraint(equalTo: calenderView.leadingAnchor, constant: CGFloat(index)*interval+interval/2).isActive = true
+        }
     }
-    
+
     override func configUI() {
         view.backgroundColor = .Background
     }
-    
-    
 
 }
+    
+
+//MARK: - Extensions
+
+extension ProfileViewController: UICollectionViewDataSource{
+    
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        weekDays
+    }
+    
+    //캘린더 아이템 수, 5일*6단위 = 30
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        18
+    }
+ }
+
+extension ProfileViewController: UICollectionViewDelegate{
+    
+    //cell 로드
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+           guard let cell = collectionView.dequeueReusableCell(
+           withReuseIdentifier: CalenderViewCell.identifier ,
+           for: indexPath) as? CalenderViewCell else {
+               return UICollectionViewCell()
+           }
+        if submittedData.contains([indexPath.section, indexPath.item]){
+                cell.backgroundColor = .lightGray
+                return cell
+        } else if calenderSlotData.blockedSlot[indexPath.section][indexPath.item] {
+            cell.backgroundColor = .Background
+
+            return cell
+        }
+        cell.backgroundColor = .white
+        return cell
+    }
+    
+    //캘린더 클릭 액션
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let cell = collectionView.cellForItem(at: indexPath) as? CalenderViewCell
+        
+        if !submittedData.contains([indexPath.section, indexPath.item]) { //빈 셀에 대해
+            if !choicedCells[indexPath.section][indexPath.item] && !calenderSlotData.blockedSlot[indexPath.section][indexPath.item] { //블락할 셀
+                choicedCells[indexPath.section][indexPath.item].toggle()
+                cell?.backgroundColor = .red
+            }else if choicedCells[indexPath.section][indexPath.item]{ //한번 클릭한 셀 해제
+                choicedCells[indexPath.section][indexPath.item].toggle()
+                cell?.backgroundColor = calenderSlotData.blockedSlot[indexPath.section][indexPath.item] ? .Background : .white
+            }else if calenderSlotData.blockedSlot[indexPath.section][indexPath.item] { //블락했던 셀
+                choicedCells[indexPath.section][indexPath.item].toggle()
+                cell?.backgroundColor = .Action
+            }
+        }
+    }
+}
+
+
+
+extension ProfileViewController: UICollectionViewDelegateFlowLayout {
+    
+    //cell 사이즈
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize{
+        return CGSize(width: (UIScreen.main.bounds.width-(calenderSidePadding[0]+calenderSidePadding[1]))/5, height: 550/18)
+    }
+    
+    //cell 횡간 간격
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat{
+        return CGFloat(0)
+    }
+    
+    //cell 종간 간격
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        return CGFloat(0)
+    }
+}
+


### PR DESCRIPTION
## 🍏 관련 이슈
<!-- 해당 PR과 관련된 이슈를 링크해주세요. -->
#103 

## 🍏 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
기존에 한 섹션으로 0~30번까지 수동 인덱싱해야 했던 캘린더를 요일별로 모두 나눔
서버 업로드/다운로드에 관여하는 인덱스<->스트링 함수 수정됨

<img width="1071" alt="스크린샷 2022-08-27 19 00 02" src="https://user-images.githubusercontent.com/70618615/187025398-3788207c-8ef4-4dd9-ac6c-73c47272f28f.png">


## 🍏 다음으로 진행될 작업
- [ ] #109 

## 🍏 주의사항
- **빈 폴더 있는지 확인하기!!**
- **파일,폴더 위치 및 이동 하지말기!!**
